### PR TITLE
fix: preserve schedule partition keys

### DIFF
--- a/samples/Atomizer.EFCore.Example/Data/MySql/Migrations/20260504195004_Initial.Designer.cs
+++ b/samples/Atomizer.EFCore.Example/Data/MySql/Migrations/20260504195004_Initial.Designer.cs
@@ -186,6 +186,10 @@ namespace Atomizer.EFCore.Example.Data.MySql.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("tinyint(1)");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("varchar(255)");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Data/MySql/Migrations/20260504195004_Initial.cs
+++ b/samples/Atomizer.EFCore.Example/Data/MySql/Migrations/20260504195004_Initial.cs
@@ -104,6 +104,9 @@ namespace Atomizer.EFCore.Example.Data.MySql.Migrations
                         MisfirePolicy = table.Column<int>(type: "int", nullable: false),
                         MaxCatchUp = table.Column<int>(type: "int", nullable: false),
                         Enabled = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                        PartitionKey = table
+                            .Column<string>(type: "varchar(255)", maxLength: 255, nullable: true)
+                            .Annotation("MySql:CharSet", "utf8mb4"),
                         RetryIntervals = table
                             .Column<string>(type: "varchar(4096)", maxLength: 4096, nullable: false)
                             .Annotation("MySql:CharSet", "utf8mb4"),

--- a/samples/Atomizer.EFCore.Example/Data/MySql/Migrations/ExampleMySqlContextModelSnapshot.cs
+++ b/samples/Atomizer.EFCore.Example/Data/MySql/Migrations/ExampleMySqlContextModelSnapshot.cs
@@ -183,6 +183,10 @@ namespace Atomizer.EFCore.Example.Data.MySql.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("tinyint(1)");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("varchar(255)");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Data/Postgres/Migrations/20260504194951_Initial.Designer.cs
+++ b/samples/Atomizer.EFCore.Example/Data/Postgres/Migrations/20260504194951_Initial.Designer.cs
@@ -186,6 +186,10 @@ namespace Atomizer.EFCore.Example.Data.Postgres.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("boolean");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("character varying(255)");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Data/Postgres/Migrations/20260504194951_Initial.cs
+++ b/samples/Atomizer.EFCore.Example/Data/Postgres/Migrations/20260504194951_Initial.cs
@@ -92,6 +92,7 @@ namespace Atomizer.EFCore.Example.Data.Postgres.Migrations
                     MisfirePolicy = table.Column<int>(type: "integer", nullable: false),
                     MaxCatchUp = table.Column<int>(type: "integer", nullable: false),
                     Enabled = table.Column<bool>(type: "boolean", nullable: false),
+                    PartitionKey = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
                     RetryIntervals = table.Column<string>(
                         type: "character varying(4096)",
                         maxLength: 4096,

--- a/samples/Atomizer.EFCore.Example/Data/Postgres/Migrations/ExamplePostgresContextModelSnapshot.cs
+++ b/samples/Atomizer.EFCore.Example/Data/Postgres/Migrations/ExamplePostgresContextModelSnapshot.cs
@@ -183,6 +183,10 @@ namespace Atomizer.EFCore.Example.Data.Postgres.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("boolean");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("character varying(255)");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Data/SqlServer/Migrations/20260504194956_Initial.Designer.cs
+++ b/samples/Atomizer.EFCore.Example/Data/SqlServer/Migrations/20260504194956_Initial.Designer.cs
@@ -186,6 +186,10 @@ namespace Atomizer.EFCore.Example.Data.SqlServer.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("bit");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("nvarchar(255)");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Data/SqlServer/Migrations/20260504194956_Initial.cs
+++ b/samples/Atomizer.EFCore.Example/Data/SqlServer/Migrations/20260504194956_Initial.cs
@@ -72,6 +72,7 @@ namespace Atomizer.EFCore.Example.Data.SqlServer.Migrations
                     MisfirePolicy = table.Column<int>(type: "int", nullable: false),
                     MaxCatchUp = table.Column<int>(type: "int", nullable: false),
                     Enabled = table.Column<bool>(type: "bit", nullable: false),
+                    PartitionKey = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
                     RetryIntervals = table.Column<string>(type: "nvarchar(max)", maxLength: 4096, nullable: false),
                     NextRunAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
                     LastEnqueueAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),

--- a/samples/Atomizer.EFCore.Example/Data/SqlServer/Migrations/ExampleSqlServerContextModelSnapshot.cs
+++ b/samples/Atomizer.EFCore.Example/Data/SqlServer/Migrations/ExampleSqlServerContextModelSnapshot.cs
@@ -183,6 +183,10 @@ namespace Atomizer.EFCore.Example.Data.SqlServer.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("bit");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("nvarchar(255)");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Data/Sqlite/Migrations/20260504195000_Initial.Designer.cs
+++ b/samples/Atomizer.EFCore.Example/Data/Sqlite/Migrations/20260504195000_Initial.Designer.cs
@@ -181,6 +181,10 @@ namespace Atomizer.EFCore.Example.Data.Sqlite.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("INTEGER");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Data/Sqlite/Migrations/20260504195000_Initial.cs
+++ b/samples/Atomizer.EFCore.Example/Data/Sqlite/Migrations/20260504195000_Initial.cs
@@ -72,6 +72,7 @@ namespace Atomizer.EFCore.Example.Data.Sqlite.Migrations
                     MisfirePolicy = table.Column<int>(type: "INTEGER", nullable: false),
                     MaxCatchUp = table.Column<int>(type: "INTEGER", nullable: false),
                     Enabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                    PartitionKey = table.Column<string>(type: "TEXT", maxLength: 255, nullable: true),
                     RetryIntervals = table.Column<string>(type: "TEXT", maxLength: 4096, nullable: false),
                     NextRunAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
                     LastEnqueueAt = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),

--- a/samples/Atomizer.EFCore.Example/Data/Sqlite/Migrations/ExampleSqliteContextModelSnapshot.cs
+++ b/samples/Atomizer.EFCore.Example/Data/Sqlite/Migrations/ExampleSqliteContextModelSnapshot.cs
@@ -178,6 +178,10 @@ namespace Atomizer.EFCore.Example.Data.Sqlite.Migrations
                     b.Property<bool>("Enabled")
                         .HasColumnType("INTEGER");
 
+                    b.Property<string>("PartitionKey")
+                        .HasMaxLength(255)
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("JobKey")
                         .IsRequired()
                         .HasMaxLength(255)

--- a/samples/Atomizer.EFCore.Example/Program.cs
+++ b/samples/Atomizer.EFCore.Example/Program.cs
@@ -87,7 +87,11 @@ await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
     "LoggerJobCatchUp",
     Schedule.Cron("0/5 * * * * *"), // Every 5 seconds,
-    options => options.MisfirePolicy = MisfirePolicy.CatchUp
+    options =>
+    {
+        options.MisfirePolicy = MisfirePolicy.CatchUp;
+        options.PartitionKey = new PartitionKey("LoggerJobCatchUp");
+    }
 );
 
 app.MapPost(

--- a/src/Atomizer.EntityFrameworkCore/Configurations/AtomizerScheduleEntityConfiguration.cs
+++ b/src/Atomizer.EntityFrameworkCore/Configurations/AtomizerScheduleEntityConfiguration.cs
@@ -39,6 +39,7 @@ public class AtomizerScheduleEntityConfiguration : IEntityTypeConfiguration<Atom
         builder.Property(e => e.MisfirePolicy).IsRequired();
         builder.Property(e => e.MaxCatchUp).IsRequired();
         builder.Property(e => e.Enabled).IsRequired();
+        builder.Property(e => e.PartitionKey).HasMaxLength(255).IsRequired(false);
         builder.Property(e => e.NextRunAt).IsRequired();
         builder.Property(e => e.LastEnqueueAt);
         builder.Property(e => e.CreatedAt).IsRequired();

--- a/src/Atomizer.EntityFrameworkCore/Entities/AtomizerScheduleEntity.cs
+++ b/src/Atomizer.EntityFrameworkCore/Entities/AtomizerScheduleEntity.cs
@@ -35,6 +35,9 @@ public class AtomizerScheduleEntity
     /// <summary>Gets or sets whether this schedule is currently active.</summary>
     public bool Enabled { get; set; } = true;
 
+    /// <summary>Gets or sets the partition key forwarded to generated jobs, if any.</summary>
+    public string? PartitionKey { get; set; }
+
     /// <summary>Gets or sets the serialized retry intervals for generated jobs.</summary>
     public TimeSpan[] RetryIntervals { get; set; } = [];
 
@@ -90,6 +93,7 @@ public static class AtomizerScheduleEntityMapper
             MisfirePolicy = (MisfirePolicyEntity)(int)schedule.MisfirePolicy,
             MaxCatchUp = schedule.MaxCatchUp,
             Enabled = schedule.Enabled,
+            PartitionKey = schedule.PartitionKey?.Key,
             RetryIntervals = schedule.RetryStrategy.RetryIntervals,
             NextRunAt = schedule.NextRunAt,
             LastEnqueueAt = schedule.LastEnqueueAt,
@@ -117,6 +121,7 @@ public static class AtomizerScheduleEntityMapper
             MisfirePolicy = (MisfirePolicy)(int)entity.MisfirePolicy,
             MaxCatchUp = entity.MaxCatchUp,
             Enabled = entity.Enabled,
+            PartitionKey = entity.PartitionKey is null ? null : new PartitionKey(entity.PartitionKey),
             RetryStrategy =
                 entity.RetryIntervals.Length == 0 ? RetryStrategy.None : RetryStrategy.Intervals(entity.RetryIntervals),
             NextRunAt = entity.NextRunAt,

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/BaseSqlDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/BaseSqlDialect.cs
@@ -36,6 +36,7 @@ internal abstract class BaseSqlDialect : ISqlDialect
     protected readonly string _sMisfirePolicy;
     protected readonly string _sMaxCatchUp;
     protected readonly string _sEnabled;
+    protected readonly string _sPartitionKey;
     protected readonly string _sRetryIntervals;
     protected readonly string _sNextRunAt;
     protected readonly string _sLastEnqueueAt;
@@ -78,6 +79,7 @@ internal abstract class BaseSqlDialect : ISqlDialect
         _sMisfirePolicy = sc[nameof(AtomizerScheduleEntity.MisfirePolicy)];
         _sMaxCatchUp = sc[nameof(AtomizerScheduleEntity.MaxCatchUp)];
         _sEnabled = sc[nameof(AtomizerScheduleEntity.Enabled)];
+        _sPartitionKey = sc[nameof(AtomizerScheduleEntity.PartitionKey)];
         _sRetryIntervals = sc[nameof(AtomizerScheduleEntity.RetryIntervals)];
         _sNextRunAt = sc[nameof(AtomizerScheduleEntity.NextRunAt)];
         _sLastEnqueueAt = sc[nameof(AtomizerScheduleEntity.LastEnqueueAt)];

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/MySqlDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/MySqlDialect.cs
@@ -150,6 +150,7 @@ internal sealed class MySqlDialect(EntityMap jobs, EntityMap schedules) : BaseSq
                 {{_sMisfirePolicy}},
                 {{_sMaxCatchUp}},
                 {{_sEnabled}},
+                {{_sPartitionKey}},
                 {{_sRetryIntervals}},
                 {{_sNextRunAt}},
                 {{_sLastEnqueueAt}},
@@ -170,7 +171,8 @@ internal sealed class MySqlDialect(EntityMap jobs, EntityMap schedules) : BaseSq
                 {11},
                 {12},
                 {13},
-                {14}
+                {14},
+                {15}
             )
             ON DUPLICATE KEY UPDATE
                 {{_sQueueKey}} = VALUES({{_sQueueKey}}),
@@ -181,9 +183,10 @@ internal sealed class MySqlDialect(EntityMap jobs, EntityMap schedules) : BaseSq
                 {{_sMisfirePolicy}} = VALUES({{_sMisfirePolicy}}),
                 {{_sMaxCatchUp}} = VALUES({{_sMaxCatchUp}}),
                 {{_sEnabled}} = VALUES({{_sEnabled}}),
+                {{_sPartitionKey}} = VALUES({{_sPartitionKey}}),
                 {{_sRetryIntervals}} = VALUES({{_sRetryIntervals}}),
                 {{_sNextRunAt}} = VALUES({{_sNextRunAt}}),
-                {{_sUpdatedAt}} = {14};
+                {{_sUpdatedAt}} = {15};
             """;
         return FormattableStringFactory.Create(
             format,
@@ -197,6 +200,7 @@ internal sealed class MySqlDialect(EntityMap jobs, EntityMap schedules) : BaseSq
             (int)entity.MisfirePolicy,
             entity.MaxCatchUp,
             entity.Enabled,
+            entity.PartitionKey,
             retryIntervals,
             entity.NextRunAt,
             entity.LastEnqueueAt,

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/PostgreSqlDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/PostgreSqlDialect.cs
@@ -149,6 +149,7 @@ internal sealed class PostgreSqlDialect(EntityMap jobs, EntityMap schedules) : B
                 {{_sMisfirePolicy}},
                 {{_sMaxCatchUp}},
                 {{_sEnabled}},
+                {{_sPartitionKey}},
                 {{_sRetryIntervals}},
                 {{_sNextRunAt}},
                 {{_sLastEnqueueAt}},
@@ -169,7 +170,8 @@ internal sealed class PostgreSqlDialect(EntityMap jobs, EntityMap schedules) : B
                 {11},
                 {12},
                 {13},
-                {14}
+                {14},
+                {15}
             )
             ON CONFLICT ({{_sJobKey}}) DO UPDATE SET
                 {{_sQueueKey}} = EXCLUDED.{{_sQueueKey}},
@@ -180,6 +182,7 @@ internal sealed class PostgreSqlDialect(EntityMap jobs, EntityMap schedules) : B
                 {{_sMisfirePolicy}} = EXCLUDED.{{_sMisfirePolicy}},
                 {{_sMaxCatchUp}} = EXCLUDED.{{_sMaxCatchUp}},
                 {{_sEnabled}} = EXCLUDED.{{_sEnabled}},
+                {{_sPartitionKey}} = EXCLUDED.{{_sPartitionKey}},
                 {{_sRetryIntervals}} = EXCLUDED.{{_sRetryIntervals}},
                 {{_sNextRunAt}} = EXCLUDED.{{_sNextRunAt}},
                 {{_sUpdatedAt}} = EXCLUDED.{{_sUpdatedAt}};
@@ -196,6 +199,7 @@ internal sealed class PostgreSqlDialect(EntityMap jobs, EntityMap schedules) : B
             (int)entity.MisfirePolicy,
             entity.MaxCatchUp,
             entity.Enabled,
+            entity.PartitionKey,
             retryIntervals,
             entity.NextRunAt,
             entity.LastEnqueueAt,

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/SqlServerDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/SqlServerDialect.cs
@@ -146,9 +146,10 @@ internal sealed class SqlServerDialect(EntityMap jobs, EntityMap schedules) : Ba
                 {{_sMisfirePolicy}} = {6},
                 {{_sMaxCatchUp}} = {7},
                 {{_sEnabled}} = {8},
-                {{_sRetryIntervals}} = {9},
-                {{_sNextRunAt}} = {10},
-                {{_sUpdatedAt}} = {11}
+                {{_sPartitionKey}} = {9},
+                {{_sRetryIntervals}} = {10},
+                {{_sNextRunAt}} = {11},
+                {{_sUpdatedAt}} = {12}
             WHEN NOT MATCHED THEN INSERT (
                 {{_sId}},
                 {{_sJobKey}},
@@ -160,13 +161,14 @@ internal sealed class SqlServerDialect(EntityMap jobs, EntityMap schedules) : Ba
                 {{_sMisfirePolicy}},
                 {{_sMaxCatchUp}},
                 {{_sEnabled}},
+                {{_sPartitionKey}},
                 {{_sRetryIntervals}},
                 {{_sNextRunAt}},
                 {{_sLastEnqueueAt}},
                 {{_sCreatedAt}},
                 {{_sUpdatedAt}}
             ) VALUES (
-                {12},
+                {13},
                 {0},
                 {1},
                 {2},
@@ -178,9 +180,10 @@ internal sealed class SqlServerDialect(EntityMap jobs, EntityMap schedules) : Ba
                 {8},
                 {9},
                 {10},
-                {13},
+                {11},
                 {14},
-                {11}
+                {15},
+                {12}
             );
             """;
         return FormattableStringFactory.Create(
@@ -194,12 +197,13 @@ internal sealed class SqlServerDialect(EntityMap jobs, EntityMap schedules) : Ba
             (int)entity.MisfirePolicy, // {6}
             entity.MaxCatchUp, // {7}
             entity.Enabled ? 1 : 0, // {8}
-            retryIntervals, // {9}
-            entity.NextRunAt, // {10}
-            now, // {11}
-            entity.Id, // {12}
-            entity.LastEnqueueAt, // {13}
-            entity.CreatedAt // {14}
+            entity.PartitionKey, // {9}
+            retryIntervals, // {10}
+            entity.NextRunAt, // {11}
+            now, // {12}
+            entity.Id, // {13}
+            entity.LastEnqueueAt, // {14}
+            entity.CreatedAt // {15}
         );
     }
 }

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
@@ -76,5 +76,6 @@ public sealed class MySqlDialectTests
         var sql = dialect.UpsertSchedule(schedule, DateTimeOffset.UtcNow);
 
         sql.Format.Should().Contain("ON DUPLICATE KEY UPDATE");
+        sql.Format.Should().Contain("PartitionKey");
     }
 }

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
@@ -78,5 +78,6 @@ public sealed class PostgreSqlDialectTests
 
         sql.Format.Should().Contain("ON CONFLICT");
         sql.Format.Should().Contain("DO UPDATE SET");
+        sql.Format.Should().Contain("PartitionKey");
     }
 }

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
@@ -78,5 +78,6 @@ public sealed class SqlServerDialectTests
 
         sql.Format.Should().Contain("MERGE");
         sql.Format.Should().Contain("WITH (HOLDLOCK)");
+        sql.Format.Should().Contain("PartitionKey");
     }
 }

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
@@ -566,7 +566,8 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             """{ "message": "New Schedule" }""",
             Schedule.EveryMinute,
             TimeZoneInfo.Utc,
-            now
+            now,
+            partitionKey: new PartitionKey("scheduled-partition")
         );
 
         await using var dbContext = _dbContextFactory();
@@ -583,9 +584,11 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
         insertedScheduleEntity.Should().NotBeNull();
         insertedScheduleEntity.JobKey.Should().Be(schedule.JobKey);
         insertedScheduleEntity.Payload.Should().Be(schedule.Payload);
+        insertedScheduleEntity.PartitionKey.Should().Be("scheduled-partition");
 
         var map = () => insertedScheduleEntity.ToAtomizerSchedule();
         map.Should().NotThrow();
+        insertedScheduleEntity.ToAtomizerSchedule().PartitionKey.Should().Be(schedule.PartitionKey);
     }
 
     [Fact]
@@ -654,6 +657,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
 
         // Act
         schedule.Payload = """{ "message": "Updated Schedule" }""";
+        schedule.PartitionKey = new PartitionKey("updated-partition");
         var scheduleId = await storage.UpsertScheduleAsync(schedule, CancellationToken.None);
         var updatedScheduleEntity = await dbContext
             .Set<AtomizerScheduleEntity>()
@@ -663,9 +667,11 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
         scheduleId.Should().Be(schedule.Id);
         updatedScheduleEntity.Should().NotBeNull();
         updatedScheduleEntity.Payload.Should().Be("""{ "message": "Updated Schedule" }""");
+        updatedScheduleEntity.PartitionKey.Should().Be("updated-partition");
 
         var map = () => updatedScheduleEntity.ToAtomizerSchedule();
         map.Should().NotThrow();
+        updatedScheduleEntity.ToAtomizerSchedule().PartitionKey.Should().Be(schedule.PartitionKey);
     }
 
     [Fact]

--- a/tests/Atomizer.Tests/Processing/JobWorkerTests.cs
+++ b/tests/Atomizer.Tests/Processing/JobWorkerTests.cs
@@ -135,8 +135,9 @@ public class JobWorkerTests
         var ioCts = new CancellationTokenSource();
         var executionCts = new CancellationTokenSource();
 
-        var nextJob = _job; // the job that should be processed after the read failure
-        var reader = new ThrowThenReturnReader(nextJob);
+        var maxReadAttempts = NonPublicSpy.GetConstant<JobWorker, int>("MaxReadAttempts");
+        var nextJob = _job; // the job that should be processed after the read failures are skipped
+        var reader = new ThrowThenReturnReader(nextJob, maxReadAttempts);
 
         var processor = Substitute.For<IJobProcessor>();
         var processedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -164,7 +165,6 @@ public class JobWorkerTests
         (await WaitOrTimeout(run, Timeout)).Should().BeTrue();
 
         // Assert
-        var maxReadAttempts = NonPublicSpy.GetConstant<JobWorker, int>("MaxReadAttempts");
         _logger
             .Received(maxReadAttempts)
             .LogWarning(Arg.Any<Exception>(), $"Worker {_workerId} channel read operation failed");
@@ -286,34 +286,36 @@ public class JobWorkerTests
     private sealed class ThrowThenReturnReader : ChannelReader<AtomizerJob>
     {
         private readonly AtomizerJob _next;
-        private int _reads;
+        private readonly int _failuresBeforeJob;
+        private int _readAttempts;
+        private int _returned;
 
-        private readonly List<object> _items = new();
-
-        public ThrowThenReturnReader(AtomizerJob next)
+        public ThrowThenReturnReader(AtomizerJob next, int failuresBeforeJob)
         {
             _next = next;
-
-            _items.Add(new Exception("unexpected read error"));
-            _items.Add(next);
+            _failuresBeforeJob = failuresBeforeJob;
         }
 
         public override async ValueTask<AtomizerJob> ReadAsync(CancellationToken cancellationToken = default)
         {
-            cancellationToken.ThrowIfCancellationRequested();
+            var attempt = Interlocked.Increment(ref _readAttempts);
 
-            await Task.Delay(50, cancellationToken); // simulate some delay
-
-            return _items[_reads] switch
+            if (attempt <= _failuresBeforeJob)
             {
-                Exception ex => throw ex,
-                _ => _next,
-            };
+                throw new InvalidOperationException("unexpected read error");
+            }
+
+            if (Interlocked.Exchange(ref _returned, 1) == 0)
+            {
+                return _next;
+            }
+
+            await Task.Delay(System.Threading.Timeout.InfiniteTimeSpan, cancellationToken);
+            throw new OperationCanceledException(cancellationToken);
         }
 
         public override bool TryRead(out AtomizerJob item)
         {
-            Interlocked.Increment(ref _reads);
             item = default!;
             return false;
         }

--- a/tests/Atomizer.Tests/Scheduling/ScheduleProcessorTests.cs
+++ b/tests/Atomizer.Tests/Scheduling/ScheduleProcessorTests.cs
@@ -59,6 +59,36 @@ public class ScheduleProcessorTests
     }
 
     [Fact]
+    public async Task ProcessAsync_WhenScheduleHasPartitionKey_ShouldInsertJobWithPartitionKey()
+    {
+        // Arrange
+        var partitionKey = new PartitionKey("scheduled-partition");
+        var schedule = AtomizerSchedule.Create(
+            new JobKey("testjob"),
+            QueueKey.Default,
+            typeof(WriteLineMessage),
+            "payload",
+            Schedule.EverySecond,
+            TimeZoneInfo.Utc,
+            _clock.UtcNow,
+            partitionKey: partitionKey
+        );
+        var horizon = _clock.UtcNow.AddSeconds(1);
+        var token = CancellationToken.None;
+
+        // Act
+        await _sut.ProcessAsync(schedule, horizon, token);
+
+        // Assert
+        await _storage
+            .Received()
+            .InsertAsync(
+                Arg.Is<AtomizerJob>(j => j.ScheduleJobKey == schedule.JobKey && j.PartitionKey == partitionKey),
+                token
+            );
+    }
+
+    [Fact]
     public async Task ProcessAsync_WhenInsertJobThrows_ShouldLogErrorAndContinue()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Persist schedule partition keys in the EF Core schedule entity, mapper, provider-specific upsert SQL, and sample migrations/snapshots.
- Add regression coverage that scheduled jobs inherit the schedule partition key and that EF schedule persistence round-trips it.
- Stabilize the flaky `RunAsync_WhenReaderThrowsUnexpected_ShouldLogAndContinueToNextJob` test with deterministic reader failures.

## Root cause
Recurring schedule options and the schedule domain model already exposed `PartitionKey`, and `ScheduleProcessor` already forwarded it to generated jobs. EF-backed storage lost the value because `AtomizerScheduleEntity` and its provider upsert SQL did not persist the schedule partition key.


