### PR TITLE
build: add csharpier tooling

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,10 @@
+{
+    "version": 1,
+    "isRoot": true,
+    "tools": {
+        "csharpier": {
+            "version": "1.2.6",
+            "commands": ["csharpier"]
+        }
+    }
+}

--- a/.csharpierignore
+++ b/.csharpierignore
@@ -1,0 +1,2 @@
+# EF Core generated migrations and model snapshots.
+**/Migrations/**

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -2,10 +2,24 @@
 on:
   push:
     branches: [ main ]
-    paths: [ 'src/**', 'tests/**' ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'samples/**'
+      - '.config/dotnet-tools.json'
+      - '.csharpierrc'
+      - '.csharpierignore'
+      - '.github/workflows/verify.yml'
   pull_request:
     branches: [ main ]
-    paths: [ 'src/**', 'tests/**' ]
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'samples/**'
+      - '.config/dotnet-tools.json'
+      - '.csharpierrc'
+      - '.csharpierignore'
+      - '.github/workflows/verify.yml'
   workflow_dispatch:
   workflow_call:
 
@@ -26,6 +40,12 @@ jobs:
             6.0.x
           cache: true
           cache-dependency-path: '**/packages.lock.json'
+
+      - name: Restore .NET tools
+        run: dotnet tool restore
+
+      - name: Check formatting
+        run: dotnet csharpier check .
 
       - name: Restore dependencies
         run: dotnet restore --locked-mode

--- a/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
+++ b/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
@@ -195,8 +195,7 @@ internal sealed class EntityFrameworkCoreStorage<TDbContext> : IAtomizerStorage
             _dbContext.ChangeTracker.Clear();
 
             var newErrors = new List<AtomizerJobErrorEntity>();
-            var jobEntities = jobs
-                .Select(j =>
+            var jobEntities = jobs.Select(j =>
                 {
                     var entity = j.ToEntity();
                     // Errors loaded via GetDueJobsAsync are always empty (no .Include); any errors

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
@@ -182,7 +182,10 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
         await act.Should().NotThrowAsync();
 
         // Assert — error was persisted
-        var errors = await dbContext.Set<AtomizerJobErrorEntity>().Where(e => e.JobId == job.Id).ToListAsync(TestContext.Current.CancellationToken);
+        var errors = await dbContext
+            .Set<AtomizerJobErrorEntity>()
+            .Where(e => e.JobId == job.Id)
+            .ToListAsync(TestContext.Current.CancellationToken);
         errors.Should().ContainSingle();
         errors[0].ErrorMessage.Should().Contain("boom");
     }


### PR DESCRIPTION
## Summary
- Pin CSharpier as a local .NET tool so contributors use the same formatter version.
- Add a CSharpier ignore file for EF Core generated migration output.
- Add CI coverage so formatting is checked in pull requests.

## Changes
- Added `.config/dotnet-tools.json` with CSharpier `1.2.6`.
- Added `.csharpierignore` for `**/Migrations/**`.
- Updated the verify workflow to restore .NET tools and run `dotnet csharpier check .`.
- Applied the current CSharpier formatting output to two existing C# files.

## Risk and rollout
- Low risk: this is tooling and formatting only, with no intended runtime behavior change.
- CI now fails on unformatted C# changes, so formatter drift is caught before merge.
- No Git hooks are added or required.

## Notes for reviewers
- The formatting gate lives in CI; local formatting remains an explicit `dotnet csharpier format .` command.