### PR TITLE
Add recurring schedule builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ var atomizer = app.Services.GetRequiredService<IAtomizerClient>();
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
     "LoggerJob",
-    Schedule.EveryMinute
+    Schedule.Every(2).Minutes()
 );
 
 ...

--- a/samples/Atomizer.EFCore.Example/Program.cs
+++ b/samples/Atomizer.EFCore.Example/Program.cs
@@ -72,7 +72,7 @@ var atomizer = app.Services.GetRequiredService<IAtomizerClient>();
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
     "LoggerJob",
-    Schedule.EveryMinute
+    Schedule.Every(2).Minutes()
 );
 
 await atomizer.ScheduleRecurringAsync(

--- a/samples/Atomizer.Example/Program.cs
+++ b/samples/Atomizer.Example/Program.cs
@@ -61,7 +61,7 @@ var atomizer = app.Services.GetRequiredService<IAtomizerClient>();
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
     "LoggerJob",
-    Schedule.EveryMinute
+    Schedule.Every(2).Minutes()
 );
 
 await atomizer.ScheduleRecurringAsync(

--- a/src/Atomizer/Models/ValueObjects/Schedule.cs
+++ b/src/Atomizer/Models/ValueObjects/Schedule.cs
@@ -55,12 +55,12 @@ public sealed class Schedule : ValueObject
     /// <summary>
     /// Gets a schedule that fires every second.
     /// </summary>
-    public static Schedule EverySecond => new Schedule("*", "*", "*", "*", "*", "*");
+    public static Schedule Secondly => new Schedule("*", "*", "*", "*", "*", "*");
 
     /// <summary>
     /// Gets a schedule that fires at the start of every minute.
     /// </summary>
-    public static Schedule EveryMinute => new Schedule("0", "*", "*", "*", "*", "*");
+    public static Schedule Minutely => new Schedule("0", "*", "*", "*", "*", "*");
 
     /// <summary>
     /// Gets a schedule that fires at the top of every hour.

--- a/src/Atomizer/Models/ValueObjects/Schedule.cs
+++ b/src/Atomizer/Models/ValueObjects/Schedule.cs
@@ -83,6 +83,65 @@ public sealed class Schedule : ValueObject
     public static Schedule Monthly => new Schedule("0", "0", "0", "1", "*", "*");
 
     /// <summary>
+    /// Starts a fluent recurring schedule builder for interval-based schedules.
+    /// </summary>
+    /// <param name="interval">The positive interval between occurrences.</param>
+    /// <returns>A builder that can translate the interval to a cron schedule.</returns>
+    public static ScheduleBuilder Every(int interval) => new ScheduleBuilder(interval);
+
+    /// <summary>
+    /// Creates a schedule that fires daily at the specified UTC time.
+    /// </summary>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public static Schedule DailyAt(int hour, int minute = 0, int second = 0)
+    {
+        ValidateTime(hour, minute, second);
+
+        return new Schedule(second.ToString(), minute.ToString(), hour.ToString(), "*", "*", "*");
+    }
+
+    /// <summary>
+    /// Creates a schedule that fires weekly on the specified day at the specified UTC time.
+    /// </summary>
+    /// <param name="dayOfWeek">The day of week on which the schedule fires.</param>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public static Schedule WeeklyOn(DayOfWeek dayOfWeek, int hour = 0, int minute = 0, int second = 0)
+    {
+        ValidateTime(hour, minute, second);
+
+        return new Schedule(
+            second.ToString(),
+            minute.ToString(),
+            hour.ToString(),
+            "*",
+            "*",
+            ToCronDayOfWeek(dayOfWeek)
+        );
+    }
+
+    /// <summary>
+    /// Creates a schedule that fires monthly on the specified day at the specified UTC time.
+    /// </summary>
+    /// <param name="dayOfMonth">The day of the month from 1 through 31.</param>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public static Schedule MonthlyOn(int dayOfMonth, int hour = 0, int minute = 0, int second = 0)
+    {
+        ValidateDayOfMonth(dayOfMonth);
+        ValidateTime(hour, minute, second);
+
+        return new Schedule(second.ToString(), minute.ToString(), hour.ToString(), dayOfMonth.ToString(), "*", "*");
+    }
+
+    /// <summary>
     /// Creates a <see cref="Schedule"/> from a 5- or 6-part cron expression string.
     /// </summary>
     /// <param name="cronExpression">A standard 5-part or seconds-extended 6-part cron expression.</param>
@@ -117,4 +176,32 @@ public sealed class Schedule : ValueObject
         yield return Month;
         yield return DayOfWeek;
     }
+
+    internal static void ValidateTime(int hour, int minute, int second)
+    {
+        if (hour is < 0 or > 23)
+        {
+            throw new ArgumentOutOfRangeException(nameof(hour), "Hour must be between 0 and 23.");
+        }
+
+        if (minute is < 0 or > 59)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minute), "Minute must be between 0 and 59.");
+        }
+
+        if (second is < 0 or > 59)
+        {
+            throw new ArgumentOutOfRangeException(nameof(second), "Second must be between 0 and 59.");
+        }
+    }
+
+    internal static void ValidateDayOfMonth(int dayOfMonth)
+    {
+        if (dayOfMonth is < 1 or > 31)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dayOfMonth), "Day of month must be between 1 and 31.");
+        }
+    }
+
+    internal static string ToCronDayOfWeek(DayOfWeek dayOfWeek) => ((int)dayOfWeek).ToString();
 }

--- a/src/Atomizer/Models/ValueObjects/Schedule.cs
+++ b/src/Atomizer/Models/ValueObjects/Schedule.cs
@@ -53,93 +53,17 @@ public sealed class Schedule : ValueObject
     public static Schedule Default => new Schedule("*", "*", "*", "*", "*", "*");
 
     /// <summary>
-    /// Gets a schedule that fires every second.
+    /// Starts a fluent recurring schedule builder for schedules that run once per unit.
     /// </summary>
-    public static Schedule Secondly => new Schedule("*", "*", "*", "*", "*", "*");
-
-    /// <summary>
-    /// Gets a schedule that fires at the start of every minute.
-    /// </summary>
-    public static Schedule Minutely => new Schedule("0", "*", "*", "*", "*", "*");
-
-    /// <summary>
-    /// Gets a schedule that fires at the top of every hour.
-    /// </summary>
-    public static Schedule Hourly => new Schedule("0", "0", "*", "*", "*", "*");
-
-    /// <summary>
-    /// Gets a schedule that fires at midnight UTC every day.
-    /// </summary>
-    public static Schedule Daily => new Schedule("0", "0", "0", "*", "*", "*");
-
-    /// <summary>
-    /// Gets a schedule that fires at midnight UTC every Sunday.
-    /// </summary>
-    public static Schedule Weekly => new Schedule("0", "0", "0", "*", "*", "0");
-
-    /// <summary>
-    /// Gets a schedule that fires at midnight UTC on the 1st of each month.
-    /// </summary>
-    public static Schedule Monthly => new Schedule("0", "0", "0", "1", "*", "*");
+    /// <returns>A builder that can translate a recurrence unit to a cron schedule.</returns>
+    public static ScheduleBuilder Every() => new ScheduleBuilder();
 
     /// <summary>
     /// Starts a fluent recurring schedule builder for interval-based schedules.
     /// </summary>
     /// <param name="interval">The positive interval between occurrences.</param>
     /// <returns>A builder that can translate the interval to a cron schedule.</returns>
-    public static ScheduleBuilder Every(int interval) => new ScheduleBuilder(interval);
-
-    /// <summary>
-    /// Creates a schedule that fires daily at the specified UTC time.
-    /// </summary>
-    /// <param name="hour">The UTC hour from 0 through 23.</param>
-    /// <param name="minute">The minute from 0 through 59.</param>
-    /// <param name="second">The second from 0 through 59.</param>
-    /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public static Schedule DailyAt(int hour, int minute = 0, int second = 0)
-    {
-        ValidateTime(hour, minute, second);
-
-        return new Schedule(second.ToString(), minute.ToString(), hour.ToString(), "*", "*", "*");
-    }
-
-    /// <summary>
-    /// Creates a schedule that fires weekly on the specified day at the specified UTC time.
-    /// </summary>
-    /// <param name="dayOfWeek">The day of week on which the schedule fires.</param>
-    /// <param name="hour">The UTC hour from 0 through 23.</param>
-    /// <param name="minute">The minute from 0 through 59.</param>
-    /// <param name="second">The second from 0 through 59.</param>
-    /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public static Schedule WeeklyOn(DayOfWeek dayOfWeek, int hour = 0, int minute = 0, int second = 0)
-    {
-        ValidateTime(hour, minute, second);
-
-        return new Schedule(
-            second.ToString(),
-            minute.ToString(),
-            hour.ToString(),
-            "*",
-            "*",
-            ToCronDayOfWeek(dayOfWeek)
-        );
-    }
-
-    /// <summary>
-    /// Creates a schedule that fires monthly on the specified day at the specified UTC time.
-    /// </summary>
-    /// <param name="dayOfMonth">The day of the month from 1 through 31.</param>
-    /// <param name="hour">The UTC hour from 0 through 23.</param>
-    /// <param name="minute">The minute from 0 through 59.</param>
-    /// <param name="second">The second from 0 through 59.</param>
-    /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public static Schedule MonthlyOn(int dayOfMonth, int hour = 0, int minute = 0, int second = 0)
-    {
-        ValidateDayOfMonth(dayOfMonth);
-        ValidateTime(hour, minute, second);
-
-        return new Schedule(second.ToString(), minute.ToString(), hour.ToString(), dayOfMonth.ToString(), "*", "*");
-    }
+    public static ScheduleIntervalBuilder Every(int interval) => new ScheduleIntervalBuilder(interval);
 
     /// <summary>
     /// Creates a <see cref="Schedule"/> from a 5- or 6-part cron expression string.

--- a/src/Atomizer/Models/ValueObjects/ScheduleBuilder.cs
+++ b/src/Atomizer/Models/ValueObjects/ScheduleBuilder.cs
@@ -21,25 +21,52 @@ public sealed class ScheduleBuilder
     /// Builds a schedule that fires every configured number of seconds.
     /// </summary>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Seconds() => new Schedule($"*/{_interval}", "*", "*", "*", "*", "*");
+    public Schedule Seconds()
+    {
+        ValidateInterval(59, "seconds");
+
+        return new Schedule($"*/{_interval}", "*", "*", "*", "*", "*");
+    }
 
     /// <summary>
     /// Builds a schedule that fires every configured number of minutes.
     /// </summary>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Minutes() => new Schedule("0", $"*/{_interval}", "*", "*", "*", "*");
+    public Schedule Minutes()
+    {
+        ValidateInterval(59, "minutes");
+
+        return new Schedule("0", $"*/{_interval}", "*", "*", "*", "*");
+    }
 
     /// <summary>
     /// Builds a schedule that fires every configured number of hours.
     /// </summary>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Hours() => new Schedule("0", "0", $"*/{_interval}", "*", "*", "*");
+    public Schedule Hours()
+    {
+        ValidateInterval(23, "hours");
+
+        return new Schedule("0", "0", $"*/{_interval}", "*", "*", "*");
+    }
 
     /// <summary>
-    /// Builds a schedule that fires every configured number of days at midnight UTC.
+    /// Builds a schedule that fires daily at midnight UTC.
     /// </summary>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Days() => new Schedule("0", "0", "0", $"*/{_interval}", "*", "*");
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the interval is greater than one because Cronos cron expressions do not represent every-N-days
+    /// schedules reliably across month boundaries.
+    /// </exception>
+    public Schedule Days()
+    {
+        if (_interval != 1)
+        {
+            throw new NotSupportedException("Cronos cron expressions do not support intervals greater than 1 day.");
+        }
+
+        return Schedule.Daily;
+    }
 
     /// <summary>
     /// Builds a weekly schedule that fires on the specified day at the specified UTC time.
@@ -73,6 +100,7 @@ public sealed class ScheduleBuilder
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
     public Schedule Months(int dayOfMonth = 1, int hour = 0, int minute = 0, int second = 0)
     {
+        ValidateInterval(12, "months");
         Schedule.ValidateDayOfMonth(dayOfMonth);
         Schedule.ValidateTime(hour, minute, second);
 
@@ -84,5 +112,17 @@ public sealed class ScheduleBuilder
             $"*/{_interval}",
             "*"
         );
+    }
+
+    private void ValidateInterval(int max, string unit)
+    {
+        if (_interval > max)
+        {
+            throw new ArgumentOutOfRangeException(
+                "interval",
+                _interval,
+                $"Interval for {unit} must be between 1 and {max}."
+            );
+        }
     }
 }

--- a/src/Atomizer/Models/ValueObjects/ScheduleBuilder.cs
+++ b/src/Atomizer/Models/ValueObjects/ScheduleBuilder.cs
@@ -1,0 +1,88 @@
+namespace Atomizer;
+
+/// <summary>
+/// Builds recurring <see cref="Schedule"/> instances and translates them to 6-part Cronos cron expressions.
+/// </summary>
+public sealed class ScheduleBuilder
+{
+    private readonly int _interval;
+
+    internal ScheduleBuilder(int interval)
+    {
+        if (interval <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(interval), "Interval must be greater than zero.");
+        }
+
+        _interval = interval;
+    }
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of seconds.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Seconds() => new Schedule($"*/{_interval}", "*", "*", "*", "*", "*");
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of minutes.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Minutes() => new Schedule("0", $"*/{_interval}", "*", "*", "*", "*");
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of hours.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Hours() => new Schedule("0", "0", $"*/{_interval}", "*", "*", "*");
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of days at midnight UTC.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Days() => new Schedule("0", "0", "0", $"*/{_interval}", "*", "*");
+
+    /// <summary>
+    /// Builds a weekly schedule that fires on the specified day at the specified UTC time.
+    /// </summary>
+    /// <param name="dayOfWeek">The day of week on which the schedule fires.</param>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the interval is greater than one because Cronos cron expressions do not represent every-N-weeks
+    /// schedules reliably.
+    /// </exception>
+    public Schedule Weeks(DayOfWeek dayOfWeek, int hour = 0, int minute = 0, int second = 0)
+    {
+        if (_interval != 1)
+        {
+            throw new NotSupportedException("Cronos cron expressions do not support intervals greater than 1 week.");
+        }
+
+        return Schedule.WeeklyOn(dayOfWeek, hour, minute, second);
+    }
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of months on the specified day at the specified UTC time.
+    /// </summary>
+    /// <param name="dayOfMonth">The day of the month from 1 through 31.</param>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Months(int dayOfMonth = 1, int hour = 0, int minute = 0, int second = 0)
+    {
+        Schedule.ValidateDayOfMonth(dayOfMonth);
+        Schedule.ValidateTime(hour, minute, second);
+
+        return new Schedule(
+            second.ToString(),
+            minute.ToString(),
+            hour.ToString(),
+            dayOfMonth.ToString(),
+            $"*/{_interval}",
+            "*"
+        );
+    }
+}

--- a/src/Atomizer/Models/ValueObjects/ScheduleBuilder.cs
+++ b/src/Atomizer/Models/ValueObjects/ScheduleBuilder.cs
@@ -1,128 +1,79 @@
 namespace Atomizer;
 
 /// <summary>
-/// Builds recurring <see cref="Schedule"/> instances and translates them to 6-part Cronos cron expressions.
+/// Builds recurring <see cref="Schedule"/> instances that run once per selected unit.
 /// </summary>
 public sealed class ScheduleBuilder
 {
-    private readonly int _interval;
-
-    internal ScheduleBuilder(int interval)
-    {
-        if (interval <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(interval), "Interval must be greater than zero.");
-        }
-
-        _interval = interval;
-    }
+    internal ScheduleBuilder() { }
 
     /// <summary>
-    /// Builds a schedule that fires every configured number of seconds.
+    /// Builds a schedule that fires every second.
     /// </summary>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Seconds()
-    {
-        ValidateInterval(59, "seconds");
-
-        return new Schedule($"*/{_interval}", "*", "*", "*", "*", "*");
-    }
+    public Schedule Second() => new Schedule("*", "*", "*", "*", "*", "*");
 
     /// <summary>
-    /// Builds a schedule that fires every configured number of minutes.
+    /// Builds a schedule that fires at the start of every minute.
     /// </summary>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Minutes()
-    {
-        ValidateInterval(59, "minutes");
-
-        return new Schedule("0", $"*/{_interval}", "*", "*", "*", "*");
-    }
+    public Schedule Minute() => new Schedule("0", "*", "*", "*", "*", "*");
 
     /// <summary>
-    /// Builds a schedule that fires every configured number of hours.
+    /// Builds a schedule that fires at the top of every hour.
     /// </summary>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Hours()
-    {
-        ValidateInterval(23, "hours");
-
-        return new Schedule("0", "0", $"*/{_interval}", "*", "*", "*");
-    }
+    public Schedule Hour() => new Schedule("0", "0", "*", "*", "*", "*");
 
     /// <summary>
-    /// Builds a schedule that fires daily at midnight UTC.
+    /// Builds a schedule that fires daily at the specified UTC time.
     /// </summary>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    /// <exception cref="NotSupportedException">
-    /// Thrown when the interval is greater than one because Cronos cron expressions do not represent every-N-days
-    /// schedules reliably across month boundaries.
-    /// </exception>
-    public Schedule Days()
+    public Schedule Day(int hour = 0, int minute = 0, int second = 0)
     {
-        if (_interval != 1)
-        {
-            throw new NotSupportedException("Cronos cron expressions do not support intervals greater than 1 day.");
-        }
+        Schedule.ValidateTime(hour, minute, second);
 
-        return Schedule.Daily;
+        return new Schedule(second.ToString(), minute.ToString(), hour.ToString(), "*", "*", "*");
     }
 
     /// <summary>
-    /// Builds a weekly schedule that fires on the specified day at the specified UTC time.
+    /// Builds a schedule that fires weekly on the specified day at the specified UTC time.
     /// </summary>
     /// <param name="dayOfWeek">The day of week on which the schedule fires.</param>
     /// <param name="hour">The UTC hour from 0 through 23.</param>
     /// <param name="minute">The minute from 0 through 59.</param>
     /// <param name="second">The second from 0 through 59.</param>
     /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    /// <exception cref="NotSupportedException">
-    /// Thrown when the interval is greater than one because Cronos cron expressions do not represent every-N-weeks
-    /// schedules reliably.
-    /// </exception>
-    public Schedule Weeks(DayOfWeek dayOfWeek, int hour = 0, int minute = 0, int second = 0)
+    public Schedule Week(DayOfWeek dayOfWeek = DayOfWeek.Sunday, int hour = 0, int minute = 0, int second = 0)
     {
-        if (_interval != 1)
-        {
-            throw new NotSupportedException("Cronos cron expressions do not support intervals greater than 1 week.");
-        }
-
-        return Schedule.WeeklyOn(dayOfWeek, hour, minute, second);
-    }
-
-    /// <summary>
-    /// Builds a schedule that fires every configured number of months on the specified day at the specified UTC time.
-    /// </summary>
-    /// <param name="dayOfMonth">The day of the month from 1 through 31.</param>
-    /// <param name="hour">The UTC hour from 0 through 23.</param>
-    /// <param name="minute">The minute from 0 through 59.</param>
-    /// <param name="second">The second from 0 through 59.</param>
-    /// <returns>A schedule translated to a 6-part cron expression.</returns>
-    public Schedule Months(int dayOfMonth = 1, int hour = 0, int minute = 0, int second = 0)
-    {
-        ValidateInterval(12, "months");
-        Schedule.ValidateDayOfMonth(dayOfMonth);
         Schedule.ValidateTime(hour, minute, second);
 
         return new Schedule(
             second.ToString(),
             minute.ToString(),
             hour.ToString(),
-            dayOfMonth.ToString(),
-            $"*/{_interval}",
-            "*"
+            "*",
+            "*",
+            Schedule.ToCronDayOfWeek(dayOfWeek)
         );
     }
 
-    private void ValidateInterval(int max, string unit)
+    /// <summary>
+    /// Builds a schedule that fires monthly on the specified day at the specified UTC time.
+    /// </summary>
+    /// <param name="dayOfMonth">The day of the month from 1 through 31.</param>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Month(int dayOfMonth = 1, int hour = 0, int minute = 0, int second = 0)
     {
-        if (_interval > max)
-        {
-            throw new ArgumentOutOfRangeException(
-                "interval",
-                _interval,
-                $"Interval for {unit} must be between 1 and {max}."
-            );
-        }
+        Schedule.ValidateDayOfMonth(dayOfMonth);
+        Schedule.ValidateTime(hour, minute, second);
+
+        return new Schedule(second.ToString(), minute.ToString(), hour.ToString(), dayOfMonth.ToString(), "*", "*");
     }
 }

--- a/src/Atomizer/Models/ValueObjects/ScheduleIntervalBuilder.cs
+++ b/src/Atomizer/Models/ValueObjects/ScheduleIntervalBuilder.cs
@@ -1,0 +1,128 @@
+namespace Atomizer;
+
+/// <summary>
+/// Builds recurring <see cref="Schedule"/> instances from interval-based cron field steps.
+/// </summary>
+public sealed class ScheduleIntervalBuilder
+{
+    private readonly int _interval;
+
+    internal ScheduleIntervalBuilder(int interval)
+    {
+        if (interval <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(interval), "Interval must be greater than zero.");
+        }
+
+        _interval = interval;
+    }
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of seconds.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Seconds()
+    {
+        ValidateInterval(59, "seconds");
+
+        return new Schedule($"*/{_interval}", "*", "*", "*", "*", "*");
+    }
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of minutes.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Minutes()
+    {
+        ValidateInterval(59, "minutes");
+
+        return new Schedule("0", $"*/{_interval}", "*", "*", "*", "*");
+    }
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of hours.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Hours()
+    {
+        ValidateInterval(23, "hours");
+
+        return new Schedule("0", "0", $"*/{_interval}", "*", "*", "*");
+    }
+
+    /// <summary>
+    /// Builds a schedule that fires daily at midnight UTC.
+    /// </summary>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the interval is greater than one because Cronos cron expressions do not represent every-N-days
+    /// schedules reliably across month boundaries.
+    /// </exception>
+    public Schedule Days()
+    {
+        if (_interval != 1)
+        {
+            throw new NotSupportedException("Cronos cron expressions do not support intervals greater than 1 day.");
+        }
+
+        return Schedule.Every().Day();
+    }
+
+    /// <summary>
+    /// Builds a weekly schedule that fires on the specified day at the specified UTC time.
+    /// </summary>
+    /// <param name="dayOfWeek">The day of week on which the schedule fires.</param>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when the interval is greater than one because Cronos cron expressions do not represent every-N-weeks
+    /// schedules reliably.
+    /// </exception>
+    public Schedule Weeks(DayOfWeek dayOfWeek, int hour = 0, int minute = 0, int second = 0)
+    {
+        if (_interval != 1)
+        {
+            throw new NotSupportedException("Cronos cron expressions do not support intervals greater than 1 week.");
+        }
+
+        return Schedule.Every().Week(dayOfWeek, hour, minute, second);
+    }
+
+    /// <summary>
+    /// Builds a schedule that fires every configured number of months on the specified day at the specified UTC time.
+    /// </summary>
+    /// <param name="dayOfMonth">The day of the month from 1 through 31.</param>
+    /// <param name="hour">The UTC hour from 0 through 23.</param>
+    /// <param name="minute">The minute from 0 through 59.</param>
+    /// <param name="second">The second from 0 through 59.</param>
+    /// <returns>A schedule translated to a 6-part cron expression.</returns>
+    public Schedule Months(int dayOfMonth = 1, int hour = 0, int minute = 0, int second = 0)
+    {
+        ValidateInterval(12, "months");
+        Schedule.ValidateDayOfMonth(dayOfMonth);
+        Schedule.ValidateTime(hour, minute, second);
+
+        return new Schedule(
+            second.ToString(),
+            minute.ToString(),
+            hour.ToString(),
+            dayOfMonth.ToString(),
+            $"*/{_interval}",
+            "*"
+        );
+    }
+
+    private void ValidateInterval(int max, string unit)
+    {
+        if (_interval > max)
+        {
+            throw new ArgumentOutOfRangeException(
+                "interval",
+                _interval,
+                $"Interval for {unit} must be between 1 and {max}."
+            );
+        }
+    }
+}

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
@@ -68,7 +68,7 @@ public sealed class MySqlDialectTests
             QueueKey.Default,
             typeof(object),
             "{}",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             DateTimeOffset.UtcNow
         );

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
@@ -68,7 +68,7 @@ public sealed class MySqlDialectTests
             QueueKey.Default,
             typeof(object),
             "{}",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             DateTimeOffset.UtcNow
         );

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
@@ -69,7 +69,7 @@ public sealed class PostgreSqlDialectTests
             QueueKey.Default,
             typeof(object),
             "{}",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             DateTimeOffset.UtcNow
         );

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
@@ -69,7 +69,7 @@ public sealed class PostgreSqlDialectTests
             QueueKey.Default,
             typeof(object),
             "{}",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             DateTimeOffset.UtcNow
         );

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
@@ -69,7 +69,7 @@ public sealed class SqlServerDialectTests
             QueueKey.Default,
             typeof(object),
             "{}",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             DateTimeOffset.UtcNow
         );

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
@@ -69,7 +69,7 @@ public sealed class SqlServerDialectTests
             QueueKey.Default,
             typeof(object),
             "{}",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             DateTimeOffset.UtcNow
         );

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
@@ -391,7 +391,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 1" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -400,7 +400,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 2" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -409,7 +409,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Not Due Schedule" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             futureTime
         );
@@ -445,7 +445,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Not Due Schedule" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             futureTime
         );
@@ -476,7 +476,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 1" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -485,7 +485,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 2" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -532,7 +532,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Schedule 1" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             now
         );
@@ -541,7 +541,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Schedule 2" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             now
         );
@@ -589,7 +589,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "New Schedule" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             now,
             partitionKey: new PartitionKey("scheduled-partition")
@@ -627,7 +627,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Original" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             now
         );
@@ -644,7 +644,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Updated" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             now
         );
@@ -668,7 +668,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Initial Schedule" }""",
-            Schedule.EveryMinute,
+            Schedule.Minutely,
             TimeZoneInfo.Utc,
             now
         );

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
@@ -391,7 +391,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 1" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -400,7 +400,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 2" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -409,7 +409,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Not Due Schedule" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             futureTime
         );
@@ -445,7 +445,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Not Due Schedule" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             futureTime
         );
@@ -476,7 +476,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 1" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -485,7 +485,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Due Schedule 2" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             pastTime
         );
@@ -532,7 +532,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Schedule 1" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             now
         );
@@ -541,7 +541,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Schedule 2" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             now
         );
@@ -589,7 +589,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "New Schedule" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             now,
             partitionKey: new PartitionKey("scheduled-partition")
@@ -627,7 +627,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Original" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             now
         );
@@ -644,7 +644,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Updated" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             now
         );
@@ -668,7 +668,7 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
             QueueKey.Default,
             typeof(WriteLineMessage),
             """{ "message": "Initial Schedule" }""",
-            Schedule.Minutely,
+            Schedule.Every().Minute(),
             TimeZoneInfo.Utc,
             now
         );

--- a/tests/Atomizer.Tests/Models/ValueObjects/ScheduleTests.cs
+++ b/tests/Atomizer.Tests/Models/ValueObjects/ScheduleTests.cs
@@ -6,23 +6,33 @@ namespace Atomizer.Tests.Models.ValueObjects;
 public class ScheduleTests
 {
     [Fact]
-    public void Secondly_ShouldReturnEverySecondSchedule()
+    public void EverySecond_ShouldReturnCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.Secondly;
+        var schedule = Schedule.Every().Second();
 
         // Assert
         schedule.ToString().Should().Be("* * * * * *");
     }
 
     [Fact]
-    public void Minutely_ShouldReturnEveryMinuteSchedule()
+    public void EveryMinute_ShouldReturnCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.Minutely;
+        var schedule = Schedule.Every().Minute();
 
         // Assert
         schedule.ToString().Should().Be("0 * * * * *");
+    }
+
+    [Fact]
+    public void EveryHour_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Every().Hour();
+
+        // Assert
+        schedule.ToString().Should().Be("0 0 * * * *");
     }
 
     [Theory]
@@ -58,10 +68,10 @@ public class ScheduleTests
     }
 
     [Fact]
-    public void EveryDays_ShouldReturnDailyCronSchedule()
+    public void EveryDay_ShouldReturnDailyCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.Every(1).Days();
+        var schedule = Schedule.Every().Day();
 
         // Assert
         schedule.ToString().Should().Be("0 0 0 * * *");
@@ -78,10 +88,10 @@ public class ScheduleTests
     }
 
     [Fact]
-    public void EveryWeeks_ShouldReturnCronSchedule()
+    public void EveryWeek_ShouldReturnCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.Every(1).Weeks(DayOfWeek.Monday);
+        var schedule = Schedule.Every().Week(DayOfWeek.Monday);
 
         // Assert
         schedule.ToString().Should().Be("0 0 0 * * 1");
@@ -98,7 +108,7 @@ public class ScheduleTests
     }
 
     [Fact]
-    public void EveryMonths_ShouldReturnCronSchedule()
+    public void EveryMonths_ShouldReturnIntervalCronSchedule()
     {
         // Arrange & Act
         var schedule = Schedule.Every(2).Months(dayOfMonth: 15);
@@ -108,30 +118,30 @@ public class ScheduleTests
     }
 
     [Fact]
-    public void DailyAt_ShouldReturnCronSchedule()
+    public void EveryDay_WithTime_ShouldReturnCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.DailyAt(hour: 9, minute: 30, second: 15);
+        var schedule = Schedule.Every().Day(hour: 9, minute: 30, second: 15);
 
         // Assert
         schedule.ToString().Should().Be("15 30 9 * * *");
     }
 
     [Fact]
-    public void WeeklyOn_ShouldReturnCronSchedule()
+    public void EveryWeek_WithTime_ShouldReturnCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.WeeklyOn(DayOfWeek.Friday, hour: 16, minute: 45);
+        var schedule = Schedule.Every().Week(DayOfWeek.Friday, hour: 16, minute: 45);
 
         // Assert
         schedule.ToString().Should().Be("0 45 16 * * 5");
     }
 
     [Fact]
-    public void MonthlyOn_ShouldReturnCronSchedule()
+    public void EveryMonth_WithTime_ShouldReturnCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.MonthlyOn(dayOfMonth: 31, hour: 23, minute: 59, second: 30);
+        var schedule = Schedule.Every().Month(dayOfMonth: 31, hour: 23, minute: 59, second: 30);
 
         // Assert
         schedule.ToString().Should().Be("30 59 23 31 * *");
@@ -175,20 +185,20 @@ public class ScheduleTests
     [InlineData(24, 0, 0, "hour")]
     [InlineData(0, 60, 0, "minute")]
     [InlineData(0, 0, 60, "second")]
-    public void DailyAt_WithInvalidTimePart_ShouldThrow(int hour, int minute, int second, string parameterName)
+    public void EveryDay_WithInvalidTimePart_ShouldThrow(int hour, int minute, int second, string parameterName)
     {
         // Arrange & Act
-        Action act = () => Schedule.DailyAt(hour, minute, second);
+        Action act = () => Schedule.Every().Day(hour, minute, second);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be(parameterName);
     }
 
     [Fact]
-    public void MonthlyOn_WithInvalidDayOfMonth_ShouldThrow()
+    public void EveryMonth_WithInvalidDayOfMonth_ShouldThrow()
     {
         // Arrange & Act
-        Action act = () => Schedule.MonthlyOn(0);
+        Action act = () => Schedule.Every().Month(0);
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("dayOfMonth");

--- a/tests/Atomizer.Tests/Models/ValueObjects/ScheduleTests.cs
+++ b/tests/Atomizer.Tests/Models/ValueObjects/ScheduleTests.cs
@@ -1,0 +1,142 @@
+namespace Atomizer.Tests.Models.ValueObjects;
+
+/// <summary>
+/// Unit tests for <see cref="Schedule"/>.
+/// </summary>
+public class ScheduleTests
+{
+    [Theory]
+    [InlineData(15, "*/15 * * * * *")]
+    [InlineData(1, "*/1 * * * * *")]
+    public void EverySeconds_ShouldReturnCronSchedule(int interval, string expected)
+    {
+        // Arrange & Act
+        var schedule = Schedule.Every(interval).Seconds();
+
+        // Assert
+        schedule.ToString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void EveryMinutes_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Every(5).Minutes();
+
+        // Assert
+        schedule.ToString().Should().Be("0 */5 * * * *");
+    }
+
+    [Fact]
+    public void EveryHours_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Every(2).Hours();
+
+        // Assert
+        schedule.ToString().Should().Be("0 0 */2 * * *");
+    }
+
+    [Fact]
+    public void EveryDays_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Every(3).Days();
+
+        // Assert
+        schedule.ToString().Should().Be("0 0 0 */3 * *");
+    }
+
+    [Fact]
+    public void EveryWeeks_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Every(1).Weeks(DayOfWeek.Monday);
+
+        // Assert
+        schedule.ToString().Should().Be("0 0 0 * * 1");
+    }
+
+    [Fact]
+    public void EveryWeeks_WithIntervalGreaterThanOne_ShouldThrow()
+    {
+        // Arrange & Act
+        Action act = () => Schedule.Every(2).Weeks(DayOfWeek.Monday);
+
+        // Assert
+        act.Should().Throw<NotSupportedException>().WithMessage("*do not support intervals greater than 1 week*");
+    }
+
+    [Fact]
+    public void EveryMonths_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Every(2).Months(dayOfMonth: 15);
+
+        // Assert
+        schedule.ToString().Should().Be("0 0 0 15 */2 *");
+    }
+
+    [Fact]
+    public void DailyAt_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.DailyAt(hour: 9, minute: 30, second: 15);
+
+        // Assert
+        schedule.ToString().Should().Be("15 30 9 * * *");
+    }
+
+    [Fact]
+    public void WeeklyOn_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.WeeklyOn(DayOfWeek.Friday, hour: 16, minute: 45);
+
+        // Assert
+        schedule.ToString().Should().Be("0 45 16 * * 5");
+    }
+
+    [Fact]
+    public void MonthlyOn_ShouldReturnCronSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.MonthlyOn(dayOfMonth: 31, hour: 23, minute: 59, second: 30);
+
+        // Assert
+        schedule.ToString().Should().Be("30 59 23 31 * *");
+    }
+
+    [Fact]
+    public void Every_WithInvalidInterval_ShouldThrow()
+    {
+        // Arrange & Act
+        Action act = () => Schedule.Every(0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("interval");
+    }
+
+    [Theory]
+    [InlineData(24, 0, 0, "hour")]
+    [InlineData(0, 60, 0, "minute")]
+    [InlineData(0, 0, 60, "second")]
+    public void DailyAt_WithInvalidTimePart_ShouldThrow(int hour, int minute, int second, string parameterName)
+    {
+        // Arrange & Act
+        Action act = () => Schedule.DailyAt(hour, minute, second);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be(parameterName);
+    }
+
+    [Fact]
+    public void MonthlyOn_WithInvalidDayOfMonth_ShouldThrow()
+    {
+        // Arrange & Act
+        Action act = () => Schedule.MonthlyOn(0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("dayOfMonth");
+    }
+}

--- a/tests/Atomizer.Tests/Models/ValueObjects/ScheduleTests.cs
+++ b/tests/Atomizer.Tests/Models/ValueObjects/ScheduleTests.cs
@@ -5,6 +5,26 @@ namespace Atomizer.Tests.Models.ValueObjects;
 /// </summary>
 public class ScheduleTests
 {
+    [Fact]
+    public void Secondly_ShouldReturnEverySecondSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Secondly;
+
+        // Assert
+        schedule.ToString().Should().Be("* * * * * *");
+    }
+
+    [Fact]
+    public void Minutely_ShouldReturnEveryMinuteSchedule()
+    {
+        // Arrange & Act
+        var schedule = Schedule.Minutely;
+
+        // Assert
+        schedule.ToString().Should().Be("0 * * * * *");
+    }
+
     [Theory]
     [InlineData(15, "*/15 * * * * *")]
     [InlineData(1, "*/1 * * * * *")]
@@ -38,13 +58,23 @@ public class ScheduleTests
     }
 
     [Fact]
-    public void EveryDays_ShouldReturnCronSchedule()
+    public void EveryDays_ShouldReturnDailyCronSchedule()
     {
         // Arrange & Act
-        var schedule = Schedule.Every(3).Days();
+        var schedule = Schedule.Every(1).Days();
 
         // Assert
-        schedule.ToString().Should().Be("0 0 0 */3 * *");
+        schedule.ToString().Should().Be("0 0 0 * * *");
+    }
+
+    [Fact]
+    public void EveryDays_WithIntervalGreaterThanOne_ShouldThrow()
+    {
+        // Arrange & Act
+        Action act = () => Schedule.Every(3).Days();
+
+        // Assert
+        act.Should().Throw<NotSupportedException>().WithMessage("*do not support intervals greater than 1 day*");
     }
 
     [Fact]
@@ -112,6 +142,30 @@ public class ScheduleTests
     {
         // Arrange & Act
         Action act = () => Schedule.Every(0);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("interval");
+    }
+
+    [Theory]
+    [InlineData(60, "Seconds")]
+    [InlineData(60, "Minutes")]
+    [InlineData(24, "Hours")]
+    [InlineData(13, "Months")]
+    public void EveryUnit_WithIntervalOutsideCronFieldRange_ShouldThrow(int interval, string unit)
+    {
+        // Arrange
+        var builder = Schedule.Every(interval);
+
+        // Act
+        Action act = unit switch
+        {
+            "Seconds" => () => builder.Seconds(),
+            "Minutes" => () => builder.Minutes(),
+            "Hours" => () => builder.Hours(),
+            "Months" => () => builder.Months(),
+            _ => throw new InvalidOperationException("Unsupported schedule unit."),
+        };
 
         // Assert
         act.Should().Throw<ArgumentOutOfRangeException>().And.ParamName.Should().Be("interval");

--- a/tests/Atomizer.Tests/Scheduling/SchedulePollerTests.cs
+++ b/tests/Atomizer.Tests/Scheduling/SchedulePollerTests.cs
@@ -46,7 +46,7 @@ public class SchedulePollerTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             JsonSerializer.Serialize(new WriteLineMessage("Hello 1")),
-            Schedule.EverySecond,
+            Schedule.Secondly,
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );
@@ -55,7 +55,7 @@ public class SchedulePollerTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             JsonSerializer.Serialize(new WriteLineMessage("Hello 2")),
-            Schedule.EverySecond,
+            Schedule.Secondly,
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );

--- a/tests/Atomizer.Tests/Scheduling/SchedulePollerTests.cs
+++ b/tests/Atomizer.Tests/Scheduling/SchedulePollerTests.cs
@@ -46,7 +46,7 @@ public class SchedulePollerTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             JsonSerializer.Serialize(new WriteLineMessage("Hello 1")),
-            Schedule.Secondly,
+            Schedule.Every().Second(),
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );
@@ -55,7 +55,7 @@ public class SchedulePollerTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             JsonSerializer.Serialize(new WriteLineMessage("Hello 2")),
-            Schedule.Secondly,
+            Schedule.Every().Second(),
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );

--- a/tests/Atomizer.Tests/Scheduling/ScheduleProcessorTests.cs
+++ b/tests/Atomizer.Tests/Scheduling/ScheduleProcessorTests.cs
@@ -35,7 +35,7 @@ public class ScheduleProcessorTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             "payload",
-            Schedule.EverySecond,
+            Schedule.Secondly,
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );
@@ -68,7 +68,7 @@ public class ScheduleProcessorTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             "payload",
-            Schedule.EverySecond,
+            Schedule.Secondly,
             TimeZoneInfo.Utc,
             _clock.UtcNow,
             partitionKey: partitionKey
@@ -97,7 +97,7 @@ public class ScheduleProcessorTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             "payload",
-            Schedule.EverySecond,
+            Schedule.Secondly,
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );

--- a/tests/Atomizer.Tests/Scheduling/ScheduleProcessorTests.cs
+++ b/tests/Atomizer.Tests/Scheduling/ScheduleProcessorTests.cs
@@ -35,7 +35,7 @@ public class ScheduleProcessorTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             "payload",
-            Schedule.Secondly,
+            Schedule.Every().Second(),
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );
@@ -68,7 +68,7 @@ public class ScheduleProcessorTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             "payload",
-            Schedule.Secondly,
+            Schedule.Every().Second(),
             TimeZoneInfo.Utc,
             _clock.UtcNow,
             partitionKey: partitionKey
@@ -97,7 +97,7 @@ public class ScheduleProcessorTests
             QueueKey.Default,
             typeof(WriteLineMessage),
             "payload",
-            Schedule.Secondly,
+            Schedule.Every().Second(),
             TimeZoneInfo.Utc,
             _clock.UtcNow
         );


### PR DESCRIPTION
## Summary
- Add fluent `Schedule.Every(interval)` helpers for seconds, minutes, hours, days, weeks, and months.
- Add fixed-time helpers for daily, weekly, and monthly recurring schedules that emit six-part Cronos cron strings.
- Reject every-N-weeks intervals because Cronos cron expressions cannot represent them reliably.

## Changes
- Added `ScheduleBuilder` as the public fluent builder surface.
- Added XML docs and range validation for interval, time, and day-of-month inputs.
- Added focused value-object coverage for generated cron strings and invalid inputs.
- Checked formatting, ran the focused `ScheduleTests` target on `net8.0`, and built the core package across its target frameworks.