### PR TITLE
feat(dashboard): add dashboard authorization options

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,93 @@ Then browse to `/atomizer` to inspect jobs, job details, schedules, queue statis
 
 If no authorization filters are configured, dashboard requests are restricted to localhost by default. Add an `IAtomizerDashboardAuthorizationFilter` through `AddAtomizerDashboard(options => options.Authorization.Add(...))` before exposing it outside local development.
 
+For production, prefer integrating with ASP.NET Core authorization:
+
+```csharp
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("AtomizerDashboard", policy =>
+        policy.RequireAuthenticatedUser().RequireRole("Operations"));
+});
+
+builder.Services.AddAtomizerDashboard(options =>
+{
+    options.Authorization.RequirePolicy("AtomizerDashboard");
+});
+```
+
+Make sure the host app runs its authentication middleware before mapping the dashboard:
+
+```csharp
+app.UseAuthentication();
+app.UseAuthorization();
+app.MapAtomizerDashboard("/atomizer");
+```
+
+The dashboard also provides shortcuts for common requirements:
+
+```csharp
+builder.Services.AddAtomizerDashboard(options =>
+{
+    options.Authorization.RequireAuthenticatedUser();
+    // or: options.Authorization.RequireRoles("Operations", "Admin");
+    // or: options.Authorization.RequireClaim("scope", "atomizer.dashboard.read");
+});
+```
+
+Multiple dashboard authorization filters are evaluated as alternatives; the first filter that authorizes a request allows it.
+
+Basic authentication is available as an explicit opt-in filter. It requires HTTPS by default:
+
+```csharp
+builder.Services.AddAtomizerDashboard(options =>
+{
+    options.Authorization.RequireBasicAuthentication(
+        builder.Configuration["AtomizerDashboard:Username"]!,
+        builder.Configuration["AtomizerDashboard:Password"]!);
+});
+```
+
+For credentials stored outside configuration, use the async validator overload:
+
+```csharp
+builder.Services.AddAtomizerDashboard(options =>
+{
+    options.Authorization.RequireBasicAuthentication(async (context, username, password) =>
+    {
+        var validator = context.RequestServices.GetRequiredService<IDashboardCredentialValidator>();
+        return await validator.ValidateAsync(username, password, context.RequestAborted);
+    });
+});
+```
+
+Custom authorization filters can also do asynchronous work:
+
+```csharp
+public sealed class DashboardAuthorizationFilter : IAtomizerDashboardAuthorizationFilter
+{
+    public async ValueTask<DashboardAuthorizationResult> AuthorizeAsync(HttpContext context)
+    {
+        var access = context.RequestServices.GetRequiredService<IDashboardAccessService>();
+        return await access.CanReadDashboardAsync(context.User, context.RequestAborted)
+            ? DashboardAuthorizationResult.Authorized
+            : DashboardAuthorizationResult.Forbidden;
+    }
+}
+```
+
+Dashboard API calls are same-origin requests and include same-origin credentials, so cookie, Windows, and other host-level authentication schemes can flow naturally. If your setup needs the embedded frontend to attach an extra request header, configure it when serving the dashboard HTML:
+
+```csharp
+builder.Services.AddAtomizerDashboard(options =>
+{
+    options.Authorization.RequirePolicy("AtomizerDashboard");
+    options.Client.RequestHeaders.Add("X-CSRF-TOKEN", context => context.Request.Cookies["X-CSRF-TOKEN"]);
+});
+```
+
+Do not put long-lived shared secrets in `Client.RequestHeaders`; those values are rendered into the dashboard page and are visible to the browser. Use them for request metadata such as CSRF tokens or short-lived per-user tokens.
+
 ## Contributing
 1. Fork the repository.
 2. Create a new branch (feature/xyz).

--- a/src/Atomizer.Dashboard/Atomizer.Dashboard.csproj
+++ b/src/Atomizer.Dashboard/Atomizer.Dashboard.csproj
@@ -27,11 +27,15 @@
     <PropertyGroup>
         <SpaProjectDir>$(MSBuildProjectDirectory)/frontend</SpaProjectDir>
     </PropertyGroup>
+    <ItemGroup>
+        <SpaSourceFiles Include="$(SpaProjectDir)/index.html" />
+        <SpaSourceFiles Include="$(SpaProjectDir)/src/**/*.*" />
+    </ItemGroup>
     <Target
         Name="BuildSpa"
         BeforeTargets="DispatchToInnerBuilds"
         Condition=" '$(SkipSpaBuild)' != 'true' AND Exists('$(SpaProjectDir)/package.json') AND '$(TargetFramework)' == '' "
-        Inputs="$(SpaProjectDir)/package-lock.json;$(SpaProjectDir)/tsconfig.json;$(SpaProjectDir)/vite.config.ts"
+        Inputs="$(SpaProjectDir)/package-lock.json;$(SpaProjectDir)/tsconfig.json;$(SpaProjectDir)/vite.config.ts;@(SpaSourceFiles)"
         Outputs="$(SpaProjectDir)/dist/index.html"
     >
         <Exec Command="node --version" ConsoleToMSBuild="true" />

--- a/src/Atomizer.Dashboard/Authorization/BasicAuthenticationDashboardAuthorizationFilter.cs
+++ b/src/Atomizer.Dashboard/Authorization/BasicAuthenticationDashboardAuthorizationFilter.cs
@@ -52,14 +52,14 @@ public sealed class BasicAuthenticationDashboardAuthorizationFilter : IAtomizerD
 
         if (!TryReadCredentials(context, out var username, out var password))
         {
-            Challenge(context);
+            DashboardAuthorizationChallenge.RegisterBasic(context, _options.Realm);
             return DashboardAuthorizationResult.Unauthorized;
         }
 
         if (await _validateCredentials(context, username, password))
             return DashboardAuthorizationResult.Authorized;
 
-        Challenge(context);
+        DashboardAuthorizationChallenge.RegisterBasic(context, _options.Realm);
         return DashboardAuthorizationResult.Unauthorized;
     }
 
@@ -111,12 +111,6 @@ public sealed class BasicAuthenticationDashboardAuthorizationFilter : IAtomizerD
         return true;
     }
 
-    private void Challenge(HttpContext context)
-    {
-        context.Response.Headers.WWWAuthenticate =
-            $"Basic realm=\"{EscapeHeaderValue(_options.Realm)}\", charset=\"UTF-8\"";
-    }
-
     private static bool FixedTimeEquals(string expected, string actual)
     {
         var expectedBytes = Encoding.UTF8.GetBytes(expected);
@@ -125,6 +119,4 @@ public sealed class BasicAuthenticationDashboardAuthorizationFilter : IAtomizerD
         return expectedBytes.Length == actualBytes.Length
             && CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes);
     }
-
-    private static string EscapeHeaderValue(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
 }

--- a/src/Atomizer.Dashboard/Authorization/BasicAuthenticationDashboardAuthorizationFilter.cs
+++ b/src/Atomizer.Dashboard/Authorization/BasicAuthenticationDashboardAuthorizationFilter.cs
@@ -1,0 +1,130 @@
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+
+namespace Atomizer.Dashboard.Authorization;
+
+/// <summary>
+/// Authorizes Atomizer Dashboard requests using HTTP Basic authentication.
+/// </summary>
+public sealed class BasicAuthenticationDashboardAuthorizationFilter : IAtomizerDashboardAuthorizationFilter
+{
+    private readonly Func<HttpContext, string, string, ValueTask<bool>> _validateCredentials;
+    private readonly DashboardBasicAuthenticationOptions _options;
+
+    /// <summary>
+    /// Creates a Basic authentication filter with fixed credentials.
+    /// </summary>
+    /// <param name="username">The required username.</param>
+    /// <param name="password">The required password.</param>
+    /// <param name="configure">Optional Basic authentication configuration.</param>
+    public BasicAuthenticationDashboardAuthorizationFilter(
+        string username,
+        string password,
+        Action<DashboardBasicAuthenticationOptions>? configure = null
+    )
+        : this(CreateFixedCredentialValidator(username, password), configure) { }
+
+    /// <summary>
+    /// Creates a Basic authentication filter with custom credential validation.
+    /// </summary>
+    /// <param name="validateCredentials">Validates the current request, username, and password.</param>
+    /// <param name="configure">Optional Basic authentication configuration.</param>
+    public BasicAuthenticationDashboardAuthorizationFilter(
+        Func<HttpContext, string, string, ValueTask<bool>> validateCredentials,
+        Action<DashboardBasicAuthenticationOptions>? configure = null
+    )
+    {
+        _validateCredentials = validateCredentials ?? throw new ArgumentNullException(nameof(validateCredentials));
+        _options = new DashboardBasicAuthenticationOptions();
+        configure?.Invoke(_options);
+        _options.Validate();
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<DashboardAuthorizationResult> AuthorizeAsync(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (_options.RequireHttps && !context.Request.IsHttps)
+            return DashboardAuthorizationResult.Forbidden;
+
+        if (!TryReadCredentials(context, out var username, out var password))
+        {
+            Challenge(context);
+            return DashboardAuthorizationResult.Unauthorized;
+        }
+
+        if (await _validateCredentials(context, username, password))
+            return DashboardAuthorizationResult.Authorized;
+
+        Challenge(context);
+        return DashboardAuthorizationResult.Unauthorized;
+    }
+
+    private static Func<HttpContext, string, string, ValueTask<bool>> CreateFixedCredentialValidator(
+        string username,
+        string password
+    )
+    {
+        if (string.IsNullOrWhiteSpace(username))
+            throw new ArgumentException("A Basic authentication username is required.", nameof(username));
+
+        if (string.IsNullOrEmpty(password))
+            throw new ArgumentException("A Basic authentication password is required.", nameof(password));
+
+        return (_, actualUsername, actualPassword) =>
+            ValueTask.FromResult(FixedTimeEquals(username, actualUsername) & FixedTimeEquals(password, actualPassword));
+    }
+
+    private static bool TryReadCredentials(HttpContext context, out string username, out string password)
+    {
+        username = string.Empty;
+        password = string.Empty;
+
+        if (
+            !AuthenticationHeaderValue.TryParse(context.Request.Headers.Authorization.ToString(), out var header)
+            || !string.Equals(header.Scheme, "Basic", StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrWhiteSpace(header.Parameter)
+        )
+        {
+            return false;
+        }
+
+        string decoded;
+        try
+        {
+            decoded = Encoding.UTF8.GetString(Convert.FromBase64String(header.Parameter));
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        var separatorIndex = decoded.IndexOf(':');
+        if (separatorIndex < 0)
+            return false;
+
+        username = decoded[..separatorIndex];
+        password = decoded[(separatorIndex + 1)..];
+        return true;
+    }
+
+    private void Challenge(HttpContext context)
+    {
+        context.Response.Headers.WWWAuthenticate =
+            $"Basic realm=\"{EscapeHeaderValue(_options.Realm)}\", charset=\"UTF-8\"";
+    }
+
+    private static bool FixedTimeEquals(string expected, string actual)
+    {
+        var expectedBytes = Encoding.UTF8.GetBytes(expected);
+        var actualBytes = Encoding.UTF8.GetBytes(actual);
+
+        return expectedBytes.Length == actualBytes.Length
+            && CryptographicOperations.FixedTimeEquals(expectedBytes, actualBytes);
+    }
+
+    private static string EscapeHeaderValue(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+}

--- a/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationChallenge.cs
+++ b/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationChallenge.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+
+namespace Atomizer.Dashboard.Authorization;
+
+internal static class DashboardAuthorizationChallenge
+{
+    private static readonly object ChallengesKey = new();
+
+    public static void RegisterBasic(HttpContext context, string realm)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        Register(context, $"Basic realm=\"{EscapeHeaderValue(realm)}\", charset=\"UTF-8\"");
+    }
+
+    public static void Apply(HttpContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (
+            !context.Items.TryGetValue(ChallengesKey, out var value)
+            || value is not List<string> challenges
+            || challenges.Count == 0
+        )
+        {
+            return;
+        }
+
+        context.Response.Headers.WWWAuthenticate = new StringValues(challenges.ToArray());
+    }
+
+    private static void Register(HttpContext context, string challenge)
+    {
+        var challenges = GetOrCreateChallenges(context);
+        if (!challenges.Contains(challenge, StringComparer.Ordinal))
+            challenges.Add(challenge);
+    }
+
+    private static List<string> GetOrCreateChallenges(HttpContext context)
+    {
+        if (context.Items.TryGetValue(ChallengesKey, out var value) && value is List<string> challenges)
+            return challenges;
+
+        challenges = [];
+        context.Items[ChallengesKey] = challenges;
+        return challenges;
+    }
+
+    private static string EscapeHeaderValue(string value) => value.Replace("\\", "\\\\").Replace("\"", "\\\"");
+}

--- a/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationFilter.cs
+++ b/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationFilter.cs
@@ -17,26 +17,18 @@ internal static class DashboardAuthorizationFilter
             options
         ) =>
         {
-            var filters =
+            var result =
                 options.Value.Authorization.Count > 0
-                    ? options.Value.Authorization
-                    : (IEnumerable<IAtomizerDashboardAuthorizationFilter>)[DefaultFilter];
+                    ? await options.Value.Authorization.AuthorizeAsync(context)
+                    : await ((IAtomizerDashboardAuthorizationFilter)DefaultFilter).AuthorizeAsync(context);
 
-            var denial = DashboardAuthorizationResult.Forbidden;
-            foreach (var filter in filters)
+            if (result == DashboardAuthorizationResult.Authorized)
             {
-                var result = filter.Authorize(context);
-                if (result == DashboardAuthorizationResult.Authorized)
-                {
-                    await handler(endpointHandler, context);
-                    return;
-                }
-
-                if (result == DashboardAuthorizationResult.Unauthorized)
-                    denial = DashboardAuthorizationResult.Unauthorized;
+                await handler(endpointHandler, context);
+                return;
             }
 
-            context.Response.StatusCode = denial == DashboardAuthorizationResult.Unauthorized ? 401 : 403;
+            context.Response.StatusCode = result == DashboardAuthorizationResult.Unauthorized ? 401 : 403;
         };
 
         return routeHandler;

--- a/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationFilter.cs
+++ b/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationFilter.cs
@@ -28,7 +28,14 @@ internal static class DashboardAuthorizationFilter
                 return;
             }
 
-            context.Response.StatusCode = result == DashboardAuthorizationResult.Unauthorized ? 401 : 403;
+            if (result == DashboardAuthorizationResult.Unauthorized)
+            {
+                DashboardAuthorizationChallenge.Apply(context);
+                context.Response.StatusCode = 401;
+                return;
+            }
+
+            context.Response.StatusCode = 403;
         };
 
         return routeHandler;

--- a/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationOptions.cs
+++ b/src/Atomizer.Dashboard/Authorization/DashboardAuthorizationOptions.cs
@@ -1,0 +1,198 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atomizer.Dashboard.Authorization;
+
+/// <summary>
+/// Configures authorization requirements for Atomizer Dashboard requests.
+/// </summary>
+/// <remarks>
+/// Dashboard authorization filters are evaluated as alternatives. The first filter that returns
+/// <see cref="DashboardAuthorizationResult.Authorized"/> allows the request.
+/// </remarks>
+public sealed class DashboardAuthorizationOptions
+{
+    private readonly List<Func<HttpContext, ValueTask<DashboardAuthorizationResult>>> _filters = [];
+
+    /// <summary>
+    /// Gets the number of configured dashboard authorization filters.
+    /// </summary>
+    public int Count => _filters.Count;
+
+    /// <summary>
+    /// Adds a custom dashboard authorization filter.
+    /// </summary>
+    /// <param name="filter">The filter to evaluate for dashboard requests.</param>
+    public void Add(IAtomizerDashboardAuthorizationFilter filter)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+
+        _filters.Add(filter.AuthorizeAsync);
+    }
+
+    /// <summary>
+    /// Adds a custom dashboard authorization delegate.
+    /// </summary>
+    /// <param name="authorize">The delegate to evaluate for dashboard requests.</param>
+    public void Add(Func<HttpContext, DashboardAuthorizationResult> authorize)
+    {
+        ArgumentNullException.ThrowIfNull(authorize);
+
+        _filters.Add(context => ValueTask.FromResult(authorize(context)));
+    }
+
+    /// <summary>
+    /// Adds an asynchronous custom dashboard authorization delegate.
+    /// </summary>
+    /// <param name="authorize">The delegate to evaluate for dashboard requests.</param>
+    public void Add(Func<HttpContext, ValueTask<DashboardAuthorizationResult>> authorize)
+    {
+        ArgumentNullException.ThrowIfNull(authorize);
+
+        _filters.Add(authorize);
+    }
+
+    /// <summary>
+    /// Requires the current ASP.NET Core user to be authenticated.
+    /// </summary>
+    public void RequireAuthenticatedUser()
+    {
+        RequireAuthorization(policy => policy.RequireAuthenticatedUser());
+    }
+
+    /// <summary>
+    /// Requires the current ASP.NET Core user to have at least one of the specified roles.
+    /// </summary>
+    /// <param name="roles">The allowed roles.</param>
+    public void RequireRoles(params string[] roles)
+    {
+        if (roles is null || roles.Length == 0)
+            throw new ArgumentException("At least one role is required.", nameof(roles));
+
+        RequireAuthorization(policy => policy.RequireAuthenticatedUser().RequireRole(roles));
+    }
+
+    /// <summary>
+    /// Requires the current ASP.NET Core user to have the specified claim.
+    /// </summary>
+    /// <param name="claimType">The required claim type.</param>
+    /// <param name="allowedValues">Optional allowed claim values.</param>
+    public void RequireClaim(string claimType, params string[] allowedValues)
+    {
+        if (string.IsNullOrWhiteSpace(claimType))
+            throw new ArgumentException("A claim type is required.", nameof(claimType));
+
+        allowedValues ??= [];
+        RequireAuthorization(policy =>
+        {
+            policy.RequireAuthenticatedUser();
+            if (allowedValues.Length == 0)
+            {
+                policy.RequireClaim(claimType);
+                return;
+            }
+
+            policy.RequireClaim(claimType, allowedValues);
+        });
+    }
+
+    /// <summary>
+    /// Requires the current ASP.NET Core user to satisfy the named authorization policy.
+    /// </summary>
+    /// <param name="policyName">The ASP.NET Core authorization policy name.</param>
+    public void RequirePolicy(string policyName)
+    {
+        if (string.IsNullOrWhiteSpace(policyName))
+            throw new ArgumentException("A policy name is required.", nameof(policyName));
+
+        _filters.Add(context => AuthorizePolicyAsync(context, policyName, policy: null));
+    }
+
+    /// <summary>
+    /// Requires the current ASP.NET Core user to satisfy a dashboard-specific authorization policy.
+    /// </summary>
+    /// <param name="configurePolicy">Configures the authorization policy.</param>
+    public void RequireAuthorization(Action<AuthorizationPolicyBuilder> configurePolicy)
+    {
+        ArgumentNullException.ThrowIfNull(configurePolicy);
+
+        var builder = new AuthorizationPolicyBuilder();
+        configurePolicy(builder);
+        var policy = builder.Build();
+
+        _filters.Add(context => AuthorizePolicyAsync(context, policyName: null, policy));
+    }
+
+    /// <summary>
+    /// Requires HTTP Basic authentication with fixed credentials.
+    /// </summary>
+    /// <param name="username">The required username.</param>
+    /// <param name="password">The required password.</param>
+    /// <param name="configure">Optional Basic authentication configuration.</param>
+    public void RequireBasicAuthentication(
+        string username,
+        string password,
+        Action<DashboardBasicAuthenticationOptions>? configure = null
+    )
+    {
+        Add(new BasicAuthenticationDashboardAuthorizationFilter(username, password, configure));
+    }
+
+    /// <summary>
+    /// Requires HTTP Basic authentication with custom asynchronous credential validation.
+    /// </summary>
+    /// <param name="validateCredentials">Validates the current request, username, and password.</param>
+    /// <param name="configure">Optional Basic authentication configuration.</param>
+    public void RequireBasicAuthentication(
+        Func<HttpContext, string, string, ValueTask<bool>> validateCredentials,
+        Action<DashboardBasicAuthenticationOptions>? configure = null
+    )
+    {
+        Add(new BasicAuthenticationDashboardAuthorizationFilter(validateCredentials, configure));
+    }
+
+    internal async ValueTask<DashboardAuthorizationResult> AuthorizeAsync(HttpContext context)
+    {
+        var denial = DashboardAuthorizationResult.Forbidden;
+        foreach (var filter in _filters)
+        {
+            var result = await filter(context);
+            if (result == DashboardAuthorizationResult.Authorized)
+                return DashboardAuthorizationResult.Authorized;
+
+            if (result == DashboardAuthorizationResult.Unauthorized)
+                denial = DashboardAuthorizationResult.Unauthorized;
+        }
+
+        return denial;
+    }
+
+    private static async ValueTask<DashboardAuthorizationResult> AuthorizePolicyAsync(
+        HttpContext context,
+        string? policyName,
+        AuthorizationPolicy? policy
+    )
+    {
+        var authorizationService =
+            context.RequestServices.GetService<IAuthorizationService>()
+            ?? throw new InvalidOperationException(
+                "Dashboard ASP.NET Core authorization requires IAuthorizationService. "
+                    + "Call services.AddAuthorization() before configuring dashboard authorization policies."
+            );
+
+        var result = policyName is not null
+            ? await authorizationService.AuthorizeAsync(context.User, context, policyName)
+            : await authorizationService.AuthorizeAsync(context.User, context, policy!);
+
+        if (result.Succeeded)
+            return DashboardAuthorizationResult.Authorized;
+
+        return IsAuthenticated(context)
+            ? DashboardAuthorizationResult.Forbidden
+            : DashboardAuthorizationResult.Unauthorized;
+    }
+
+    private static bool IsAuthenticated(HttpContext context) =>
+        context.User.Identities.Any(identity => identity.IsAuthenticated);
+}

--- a/src/Atomizer.Dashboard/Authorization/DashboardBasicAuthenticationOptions.cs
+++ b/src/Atomizer.Dashboard/Authorization/DashboardBasicAuthenticationOptions.cs
@@ -1,0 +1,26 @@
+namespace Atomizer.Dashboard.Authorization;
+
+/// <summary>
+/// Configures the built-in Atomizer Dashboard Basic authentication filter.
+/// </summary>
+public sealed class DashboardBasicAuthenticationOptions
+{
+    /// <summary>
+    /// Gets or sets the Basic authentication realm displayed by clients. Defaults to <c>Atomizer Dashboard</c>.
+    /// </summary>
+    public string Realm { get; set; } = "Atomizer Dashboard";
+
+    /// <summary>
+    /// Gets or sets whether Basic authentication requires HTTPS. Defaults to <see langword="true"/>.
+    /// </summary>
+    public bool RequireHttps { get; set; } = true;
+
+    internal void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(Realm))
+            throw new ArgumentException("A Basic authentication realm is required.", nameof(Realm));
+
+        if (Realm.Contains('\r') || Realm.Contains('\n'))
+            throw new ArgumentException("The Basic authentication realm cannot contain line breaks.", nameof(Realm));
+    }
+}

--- a/src/Atomizer.Dashboard/Authorization/IAtomizerDashboardAuthorizationFilter.cs
+++ b/src/Atomizer.Dashboard/Authorization/IAtomizerDashboardAuthorizationFilter.cs
@@ -12,6 +12,23 @@ namespace Atomizer.Dashboard.Authorization;
 /// </summary>
 public interface IAtomizerDashboardAuthorizationFilter
 {
-    /// <summary>Evaluates whether the request should be allowed.</summary>
-    DashboardAuthorizationResult Authorize(HttpContext context);
+    /// <summary>
+    /// Asynchronously evaluates whether the request should be allowed.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    ValueTask<DashboardAuthorizationResult> AuthorizeAsync(HttpContext context) =>
+        ValueTask.FromResult(Authorize(context));
+
+    /// <summary>
+    /// Evaluates whether the request should be allowed.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <remarks>
+    /// Implement this for simple synchronous filters. Implement <see cref="AuthorizeAsync"/> for filters that
+    /// need asynchronous work.
+    /// </remarks>
+    DashboardAuthorizationResult Authorize(HttpContext context) =>
+        throw new NotSupportedException(
+            $"Implement {nameof(AuthorizeAsync)} for asynchronous dashboard authorization filters."
+        );
 }

--- a/src/Atomizer.Dashboard/Configuration/DashboardClientOptions.cs
+++ b/src/Atomizer.Dashboard/Configuration/DashboardClientOptions.cs
@@ -1,0 +1,16 @@
+namespace Atomizer.Dashboard.Configuration;
+
+/// <summary>
+/// Configures client-side behavior for the embedded Atomizer Dashboard SPA.
+/// </summary>
+public sealed class DashboardClientOptions
+{
+    /// <summary>
+    /// Headers that the embedded dashboard frontend attaches to dashboard API requests.
+    /// </summary>
+    /// <remarks>
+    /// Use these headers for same-origin request metadata such as CSRF tokens or short-lived per-user tokens.
+    /// Do not put long-lived shared secrets in the dashboard HTML.
+    /// </remarks>
+    public DashboardClientRequestHeaderCollection RequestHeaders { get; } = new();
+}

--- a/src/Atomizer.Dashboard/Configuration/DashboardClientRequestHeaderCollection.cs
+++ b/src/Atomizer.Dashboard/Configuration/DashboardClientRequestHeaderCollection.cs
@@ -1,0 +1,113 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Atomizer.Dashboard.Configuration;
+
+/// <summary>
+/// Configures request headers that the embedded dashboard frontend sends to dashboard API endpoints.
+/// </summary>
+public sealed class DashboardClientRequestHeaderCollection
+{
+    private const string InvalidHeaderNameChars = "()<>@,;:\\\"/[]?={} \t";
+    private readonly List<DashboardClientRequestHeader> _headers = [];
+
+    /// <summary>
+    /// Gets the number of configured request headers.
+    /// </summary>
+    public int Count => _headers.Count;
+
+    /// <summary>
+    /// Adds a static request header value.
+    /// </summary>
+    /// <param name="name">The HTTP header name.</param>
+    /// <param name="value">The HTTP header value.</param>
+    public void Add(string name, string value)
+    {
+        ValidateHeaderName(name);
+        ValidateHeaderValue(value);
+
+        _headers.Add(new DashboardClientRequestHeader(name, _ => ValueTask.FromResult<string?>(value)));
+    }
+
+    /// <summary>
+    /// Adds a request header value produced from the current dashboard HTML request.
+    /// </summary>
+    /// <param name="name">The HTTP header name.</param>
+    /// <param name="valueFactory">Creates the HTTP header value. Return <see langword="null"/> to omit the header.</param>
+    public void Add(string name, Func<HttpContext, string?> valueFactory)
+    {
+        ArgumentNullException.ThrowIfNull(valueFactory);
+        ValidateHeaderName(name);
+
+        _headers.Add(new DashboardClientRequestHeader(name, context => ValueTask.FromResult(valueFactory(context))));
+    }
+
+    /// <summary>
+    /// Adds an asynchronous request header value produced from the current dashboard HTML request.
+    /// </summary>
+    /// <param name="name">The HTTP header name.</param>
+    /// <param name="valueFactory">Creates the HTTP header value. Return <see langword="null"/> to omit the header.</param>
+    public void Add(string name, Func<HttpContext, ValueTask<string?>> valueFactory)
+    {
+        ArgumentNullException.ThrowIfNull(valueFactory);
+        ValidateHeaderName(name);
+
+        _headers.Add(new DashboardClientRequestHeader(name, valueFactory));
+    }
+
+    internal async ValueTask<IReadOnlyDictionary<string, string>> BuildAsync(HttpContext context)
+    {
+        if (_headers.Count == 0)
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var header in _headers)
+        {
+            var value = await header.GetValueAsync(context);
+            if (value is null)
+                continue;
+
+            ValidateHeaderValue(value);
+            headers[header.Name] = value;
+        }
+
+        return headers;
+    }
+
+    private static void ValidateHeaderName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("A header name is required.", nameof(name));
+
+        foreach (var character in name)
+        {
+            if (character <= 32 || character >= 127 || InvalidHeaderNameChars.IndexOf(character) >= 0)
+                throw new ArgumentException($"'{name}' is not a valid HTTP header name.", nameof(name));
+        }
+    }
+
+    private static void ValidateHeaderValue(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (value.Contains('\r') || value.Contains('\n'))
+            throw new ArgumentException(
+                "Header values cannot contain carriage return or line feed characters.",
+                nameof(value)
+            );
+    }
+
+    private sealed class DashboardClientRequestHeader
+    {
+        private readonly Func<HttpContext, ValueTask<string?>> _valueFactory;
+
+        public DashboardClientRequestHeader(string name, Func<HttpContext, ValueTask<string?>> valueFactory)
+        {
+            Name = name;
+            _valueFactory = valueFactory;
+        }
+
+        public string Name { get; }
+
+        public ValueTask<string?> GetValueAsync(HttpContext context) => _valueFactory(context);
+    }
+}

--- a/src/Atomizer.Dashboard/Configuration/DashboardOptions.cs
+++ b/src/Atomizer.Dashboard/Configuration/DashboardOptions.cs
@@ -31,6 +31,10 @@ public sealed class DashboardOptions
     /// Authorization filters applied to all dashboard requests.
     /// If empty, only localhost requests are allowed by default.
     /// </summary>
-    public IList<IAtomizerDashboardAuthorizationFilter> Authorization { get; } =
-        new List<IAtomizerDashboardAuthorizationFilter>();
+    public DashboardAuthorizationOptions Authorization { get; } = new();
+
+    /// <summary>
+    /// Client-side options for the embedded dashboard frontend.
+    /// </summary>
+    public DashboardClientOptions Client { get; } = new();
 }

--- a/src/Atomizer.Dashboard/Configuration/DashboardServiceCollectionExtensions.cs
+++ b/src/Atomizer.Dashboard/Configuration/DashboardServiceCollectionExtensions.cs
@@ -15,8 +15,8 @@ public static class DashboardServiceCollectionExtensions
     /// Call <see cref="DashboardEndpointRouteExtensions.MapAtomizerDashboard"/> to map routes.
     /// </summary>
     /// <remarks>
-    /// WARNING: The dashboard exposes job payloads and is not authenticated in v1.
-    /// Do not use in production environments without configuring authorization filters.
+    /// The dashboard exposes job payloads. If no authorization is configured, requests are limited to localhost.
+    /// Configure <see cref="DashboardOptions.Authorization"/> before exposing the dashboard outside local development.
     /// </remarks>
     public static IServiceCollection AddAtomizerDashboard(
         this IServiceCollection services,

--- a/src/Atomizer.Dashboard/StaticFiles/EmbeddedSpaFileProvider.cs
+++ b/src/Atomizer.Dashboard/StaticFiles/EmbeddedSpaFileProvider.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 using Atomizer.Dashboard.Configuration;
 using Microsoft.AspNetCore.Http;
 
@@ -8,7 +10,7 @@ internal static class EmbeddedSpaFileProvider
 {
     private static readonly Assembly Assembly = typeof(EmbeddedSpaFileProvider).Assembly;
     private const string ResourcePrefix = "Atomizer.Dashboard.Spa.";
-    private static string? _cachedIndexHtml;
+    private static string? _cachedIndexHtmlTemplate;
 
     /// <summary>
     /// Serves the embedded SPA asset matching the request path, or falls back to
@@ -37,29 +39,45 @@ internal static class EmbeddedSpaFileProvider
 
     public static async Task ServeIndexAsync(HttpContext context, string routePrefix, DashboardOptions options)
     {
-        var html = _cachedIndexHtml ??= BuildIndexHtml(options, routePrefix);
+        var html = await BuildIndexHtmlAsync(context, options, routePrefix);
 
         context.Response.ContentType = "text/html; charset=utf-8";
         context.Response.Headers.ETag = GetETag();
         await context.Response.WriteAsync(html);
     }
 
-    private static string BuildIndexHtml(DashboardOptions options, string routePrefix)
+    private static async ValueTask<string> BuildIndexHtmlAsync(
+        HttpContext context,
+        DashboardOptions options,
+        string routePrefix
+    )
     {
+        var baseHref = routePrefix.TrimEnd('/') + "/";
+        var apiRequestHeaders = await options.Client.RequestHeaders.BuildAsync(context);
+        var apiRequestHeadersJson = JsonSerializer.Serialize(apiRequestHeaders);
+        var encoder = HtmlEncoder.Default;
+
+        return ReadIndexHtmlTemplate()
+            .Replace("<head>", $"<head>\n    <base href=\"{encoder.Encode(baseHref)}\">")
+            .Replace("{{ROUTE_PREFIX}}", encoder.Encode(routePrefix))
+            .Replace("{{TITLE}}", encoder.Encode(options.Title))
+            .Replace("{{STATS_REFRESH_MS}}", ((int)options.StatsRefreshInterval.TotalMilliseconds).ToString())
+            .Replace("{{JOBS_REFRESH_MS}}", ((int)options.JobsRefreshInterval.TotalMilliseconds).ToString())
+            .Replace("{{API_REQUEST_HEADERS}}", encoder.Encode(apiRequestHeadersJson));
+    }
+
+    private static string ReadIndexHtmlTemplate()
+    {
+        if (_cachedIndexHtmlTemplate is not null)
+            return _cachedIndexHtmlTemplate;
+
         using var stream = Assembly.GetManifestResourceStream(ResourcePrefix + "index.html");
         if (stream is null)
             throw new InvalidOperationException("Embedded index.html not found in Atomizer.Dashboard assembly.");
 
-        var baseHref = routePrefix.TrimEnd('/') + "/";
-
         using var reader = new StreamReader(stream);
-        return reader
-            .ReadToEnd()
-            .Replace("<head>", $"<head>\n    <base href=\"{baseHref}\">")
-            .Replace("{{ROUTE_PREFIX}}", routePrefix)
-            .Replace("{{TITLE}}", options.Title)
-            .Replace("{{STATS_REFRESH_MS}}", ((int)options.StatsRefreshInterval.TotalMilliseconds).ToString())
-            .Replace("{{JOBS_REFRESH_MS}}", ((int)options.JobsRefreshInterval.TotalMilliseconds).ToString());
+        _cachedIndexHtmlTemplate = reader.ReadToEnd();
+        return _cachedIndexHtmlTemplate;
     }
 
     private static string GetETag()

--- a/src/Atomizer.Dashboard/frontend/index.html
+++ b/src/Atomizer.Dashboard/frontend/index.html
@@ -9,6 +9,7 @@
       data-title="{{TITLE}}"
       data-stats-refresh-ms="{{STATS_REFRESH_MS}}"
       data-jobs-refresh-ms="{{JOBS_REFRESH_MS}}"
+      data-api-request-headers="{{API_REQUEST_HEADERS}}"
     />
     <title>{{TITLE}}</title>
   </head>

--- a/src/Atomizer.Dashboard/frontend/src/api/client.ts
+++ b/src/Atomizer.Dashboard/frontend/src/api/client.ts
@@ -1,12 +1,22 @@
-import { routePrefix } from '../config';
+import { apiRequestHeaders, routePrefix } from '../config';
 import type { PagedResponse, JobDto, JobDetailDto, ScheduleDto, QueueStatsResponse, ServerDto } from './types';
 
 const baseUrl = `${window.location.origin}${routePrefix}/api`;
 
+function buildHeaders(initHeaders?: HeadersInit): Headers {
+    const headers = new Headers({ Accept: 'application/json' });
+
+    Object.entries(apiRequestHeaders).forEach(([name, value]) => headers.set(name, value));
+    new Headers(initHeaders).forEach((value, name) => headers.set(name, value));
+
+    return headers;
+}
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
     const res = await fetch(`${baseUrl}${path}`, {
-        headers: { Accept: 'application/json', ...init?.headers },
         ...init,
+        credentials: init?.credentials ?? 'same-origin',
+        headers: buildHeaders(init?.headers),
     });
     if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${path}`);
     return res.json() as Promise<T>;

--- a/src/Atomizer.Dashboard/frontend/src/config.ts
+++ b/src/Atomizer.Dashboard/frontend/src/config.ts
@@ -15,6 +15,21 @@ function readNumber(value: string | undefined, fallback: number): number {
     return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+function readStringRecord(value: string | undefined): Record<string, string> {
+    const raw = readString(value, '{}');
+
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+
+        return Object.fromEntries(
+            Object.entries(parsed).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+        );
+    } catch {
+        return {};
+    }
+}
+
 function normalizeRoutePrefix(value: string): string {
     const trimmed = value.trim();
     if (!trimmed || trimmed === '/') return '';
@@ -31,3 +46,4 @@ export const title: string = readString(
 );
 export const statsRefreshMs: number = readNumber(meta?.dataset.statsRefreshMs, 5000);
 export const jobsRefreshMs: number = readNumber(meta?.dataset.jobsRefreshMs, 30000);
+export const apiRequestHeaders: Record<string, string> = readStringRecord(meta?.dataset.apiRequestHeaders);

--- a/tests/Atomizer.Dashboard.Tests/Authorization/BasicAuthenticationAuthorizationFilterTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Authorization/BasicAuthenticationAuthorizationFilterTests.cs
@@ -1,0 +1,82 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Atomizer.Dashboard.Authorization;
+using Atomizer.Dashboard.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atomizer.Dashboard.Tests.Authorization;
+
+public class BasicAuthenticationAuthorizationFilterTests
+{
+    [Fact]
+    public async Task AuthorizeAsync_WhenBasicAuthCredentialsMatchOverHttps_ShouldReturnAuthorized()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireBasicAuthentication("operator", "secret");
+        var context = CreateContext("operator", "secret");
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenBasicAuthCredentialsDoNotMatch_ShouldReturnUnauthorizedAndChallenge()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireBasicAuthentication("operator", "secret");
+        var context = CreateContext("operator", "wrong");
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Unauthorized);
+        context.Response.Headers.WWWAuthenticate.ToString().Should().Contain("Basic");
+        context.Response.Headers.WWWAuthenticate.ToString().Should().Contain("Atomizer Dashboard");
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenBasicAuthRequiresHttpsAndRequestIsHttp_ShouldReturnForbidden()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireBasicAuthentication("operator", "secret");
+        var context = CreateContext("operator", "secret");
+        context.Request.Scheme = "http";
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Forbidden);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenBasicAuthUsesAsyncValidator_ShouldReturnValidatorResult()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireBasicAuthentication(
+            async (_, username, password) =>
+            {
+                await Task.Yield();
+                return username == "operator" && password == "secret";
+            }
+        );
+        var context = CreateContext("operator", "secret");
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+    }
+
+    private static HttpContext CreateContext(string username, string password)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var context = new DefaultHttpContext { RequestServices = services.BuildServiceProvider(validateScopes: true) };
+        context.Request.Scheme = "https";
+        context.Request.Headers.Authorization = new AuthenticationHeaderValue(
+            "Basic",
+            Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"))
+        ).ToString();
+
+        return context;
+    }
+}

--- a/tests/Atomizer.Dashboard.Tests/Authorization/BasicAuthenticationAuthorizationFilterTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Authorization/BasicAuthenticationAuthorizationFilterTests.cs
@@ -22,7 +22,7 @@ public class BasicAuthenticationAuthorizationFilterTests
     }
 
     [Fact]
-    public async Task AuthorizeAsync_WhenBasicAuthCredentialsDoNotMatch_ShouldReturnUnauthorizedAndChallenge()
+    public async Task AuthorizeAsync_WhenBasicAuthCredentialsDoNotMatchAndChallengeApplied_ShouldReturnUnauthorizedAndChallenge()
     {
         var options = new DashboardOptions();
         options.Authorization.RequireBasicAuthentication("operator", "secret");
@@ -31,8 +31,26 @@ public class BasicAuthenticationAuthorizationFilterTests
         var result = await options.Authorization.AuthorizeAsync(context);
 
         result.Should().Be(DashboardAuthorizationResult.Unauthorized);
+        context.Response.Headers.WWWAuthenticate.Should().BeEmpty();
+
+        DashboardAuthorizationChallenge.Apply(context);
+
         context.Response.Headers.WWWAuthenticate.ToString().Should().Contain("Basic");
         context.Response.Headers.WWWAuthenticate.ToString().Should().Contain("Atomizer Dashboard");
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenBasicAuthRejectsButLaterFilterAuthorizes_ShouldNotWriteChallenge()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireBasicAuthentication("operator", "secret");
+        options.Authorization.Add(_ => DashboardAuthorizationResult.Authorized);
+        var context = CreateContext("operator", "wrong");
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+        context.Response.Headers.WWWAuthenticate.Should().BeEmpty();
     }
 
     [Fact]

--- a/tests/Atomizer.Dashboard.Tests/Authorization/DashboardAuthorizationOptionsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Authorization/DashboardAuthorizationOptionsTests.cs
@@ -1,0 +1,156 @@
+using System.Security.Claims;
+using Atomizer.Dashboard.Authorization;
+using Atomizer.Dashboard.Configuration;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atomizer.Dashboard.Tests.Authorization;
+
+public class DashboardAuthorizationOptionsTests
+{
+    [Fact]
+    public async Task AuthorizeAsync_WhenAuthenticatedUserRequiredAndPrincipalIsAuthenticated_ShouldReturnAuthorized()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireAuthenticatedUser();
+        var context = CreateContext(
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "operator")], "Test"))
+        );
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenAuthenticatedUserRequiredAndPrincipalIsAnonymous_ShouldReturnUnauthorized()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireAuthenticatedUser();
+        var context = CreateContext(new ClaimsPrincipal(new ClaimsIdentity()));
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Unauthorized);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenRoleRequiredAndPrincipalHasRole_ShouldReturnAuthorized()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireRoles("atomizer-operators");
+        var context = CreateContext(
+            new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, "operator"), new Claim(ClaimTypes.Role, "atomizer-operators")],
+                    "Test"
+                )
+            )
+        );
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenRoleRequiredAndPrincipalIsAuthenticatedWithoutRole_ShouldReturnForbidden()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireRoles("atomizer-operators");
+        var context = CreateContext(
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "operator")], "Test"))
+        );
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Forbidden);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenClaimRequiredAndPrincipalHasClaimValue_ShouldReturnAuthorized()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequireClaim("scope", "atomizer.dashboard.read");
+        var context = CreateContext(
+            new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, "operator"), new Claim("scope", "atomizer.dashboard.read")],
+                    "Test"
+                )
+            )
+        );
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenNamedPolicyMatchesPrincipal_ShouldReturnAuthorized()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.RequirePolicy("AtomizerDashboard");
+        var context = CreateContext(
+            new ClaimsPrincipal(
+                new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, "operator"), new Claim("scope", "atomizer.dashboard.read")],
+                    "Test"
+                )
+            ),
+            services =>
+                services.AddAuthorization(options =>
+                    options.AddPolicy(
+                        "AtomizerDashboard",
+                        policy => policy.RequireClaim("scope", "atomizer.dashboard.read")
+                    )
+                )
+        );
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+    }
+
+    [Fact]
+    public async Task AuthorizeAsync_WhenCustomFilterUsesAsyncWork_ShouldReturnFilterResult()
+    {
+        var options = new DashboardOptions();
+        options.Authorization.Add(new AsyncAllowAuthorizationFilter());
+        var context = CreateContext(new ClaimsPrincipal(new ClaimsIdentity()));
+
+        var result = await options.Authorization.AuthorizeAsync(context);
+
+        result.Should().Be(DashboardAuthorizationResult.Authorized);
+        context.Items.Should().ContainKey("async-filter");
+    }
+
+    private static HttpContext CreateContext(ClaimsPrincipal user, Action<IServiceCollection>? configureServices = null)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        if (configureServices is null)
+            services.AddAuthorization();
+        else
+            configureServices(services);
+
+        var context = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(validateScopes: true),
+            User = user,
+        };
+
+        return context;
+    }
+
+    private sealed class AsyncAllowAuthorizationFilter : IAtomizerDashboardAuthorizationFilter
+    {
+        public async ValueTask<DashboardAuthorizationResult> AuthorizeAsync(HttpContext context)
+        {
+            await Task.Yield();
+            context.Items["async-filter"] = true;
+
+            return DashboardAuthorizationResult.Authorized;
+        }
+    }
+}

--- a/tests/Atomizer.Dashboard.Tests/Configuration/DashboardClientOptionsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Configuration/DashboardClientOptionsTests.cs
@@ -1,0 +1,26 @@
+using Atomizer.Dashboard.Configuration;
+
+namespace Atomizer.Dashboard.Tests.Configuration;
+
+public class DashboardClientOptionsTests
+{
+    [Fact]
+    public void AddRequestHeader_WhenHeaderNameContainsNewLine_ShouldThrowArgumentException()
+    {
+        var options = new DashboardOptions();
+
+        var act = () => options.Client.RequestHeaders.Add("X-Atomizer\r\nInjected", "value");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void AddRequestHeader_WhenHeaderValueContainsNewLine_ShouldThrowArgumentException()
+    {
+        var options = new DashboardOptions();
+
+        var act = () => options.Client.RequestHeaders.Add("X-Atomizer-Token", "value\r\nInjected");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Atomizer.Dashboard.Tests/Endpoints/AuthorizationTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Endpoints/AuthorizationTests.cs
@@ -39,6 +39,18 @@ public class AuthorizationTests
     }
 
     [Fact]
+    public async Task GetJobs_WhenBasicAuthenticationRejects_ShouldReturn401WithChallenge()
+    {
+        using var host = new BasicAuthenticationTestHost();
+        var client = host.CreateClient();
+
+        var response = await client.GetAsync("/atomizer/api/jobs", TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        response.Headers.WwwAuthenticate.Should().Contain(header => header.Scheme == "Basic");
+    }
+
+    [Fact]
     public async Task GetJobById_WhenAuthFilterRejectsForbidden_ShouldReturn403()
     {
         using var host = new DenyAllTestHost();

--- a/tests/Atomizer.Dashboard.Tests/Endpoints/AuthorizationTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Endpoints/AuthorizationTests.cs
@@ -50,4 +50,17 @@ public class AuthorizationTests
         );
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
+
+    [Fact]
+    public async Task Index_WhenClientRequestHeaderConfigured_ShouldRenderApiRequestHeaderConfiguration()
+    {
+        using var host = new ClientRequestHeaderTestHost();
+        var client = host.CreateClient();
+
+        var html = await client.GetStringAsync("/atomizer", TestContext.Current.CancellationToken);
+
+        html.Should().Contain("data-api-request-headers=");
+        html.Should().Contain("X-Atomizer-Dashboard-Request");
+        html.Should().Contain("test-token");
+    }
 }

--- a/tests/Atomizer.Dashboard.Tests/TestHost.cs
+++ b/tests/Atomizer.Dashboard.Tests/TestHost.cs
@@ -67,6 +67,20 @@ public sealed class UnauthorizedTestHost : DashboardHostBase
     protected override IAtomizerDashboardAuthorizationFilter AuthFilter { get; } = new UnauthorizedAuthFilter();
 }
 
+public sealed class BasicAuthenticationTestHost : DashboardHostBase
+{
+    protected override IAtomizerDashboardAuthorizationFilter AuthFilter { get; } = new UnauthorizedAuthFilter();
+
+    protected override void ConfigureDashboard(DashboardOptions options)
+    {
+        options.Authorization.RequireBasicAuthentication(
+            "operator",
+            "secret",
+            basicOptions => basicOptions.RequireHttps = false
+        );
+    }
+}
+
 public sealed class ClientRequestHeaderTestHost : DashboardHostBase
 {
     protected override IAtomizerDashboardAuthorizationFilter AuthFilter { get; } = new AlwaysAllowAuthFilter();

--- a/tests/Atomizer.Dashboard.Tests/TestHost.cs
+++ b/tests/Atomizer.Dashboard.Tests/TestHost.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Atomizer;
 using Atomizer.Abstractions;
 using Atomizer.Dashboard.Authorization;
+using Atomizer.Dashboard.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -31,7 +32,7 @@ public abstract class DashboardHostBase : WebApplicationFactory<Program>
                     services.AddSingleton(sp =>
                         (Atomizer.Storage.InMemoryStorage)sp.GetRequiredService<IAtomizerStorage>()
                     );
-                    services.AddAtomizerDashboard(options => options.Authorization.Add(AuthFilter));
+                    services.AddAtomizerDashboard(ConfigureDashboard);
                 });
                 web.Configure(app =>
                 {
@@ -44,6 +45,11 @@ public abstract class DashboardHostBase : WebApplicationFactory<Program>
         builder.UseContentRoot(AppContext.BaseDirectory);
 
     protected override IEnumerable<Assembly> GetTestAssemblies() => [];
+
+    protected virtual void ConfigureDashboard(DashboardOptions options)
+    {
+        options.Authorization.Add(AuthFilter);
+    }
 }
 
 public sealed class DashboardTestHost : DashboardHostBase
@@ -59,6 +65,17 @@ public sealed class DenyAllTestHost : DashboardHostBase
 public sealed class UnauthorizedTestHost : DashboardHostBase
 {
     protected override IAtomizerDashboardAuthorizationFilter AuthFilter { get; } = new UnauthorizedAuthFilter();
+}
+
+public sealed class ClientRequestHeaderTestHost : DashboardHostBase
+{
+    protected override IAtomizerDashboardAuthorizationFilter AuthFilter { get; } = new AlwaysAllowAuthFilter();
+
+    protected override void ConfigureDashboard(DashboardOptions options)
+    {
+        base.ConfigureDashboard(options);
+        options.Client.RequestHeaders.Add("X-Atomizer-Dashboard-Request", _ => "test-token");
+    }
 }
 
 public sealed class DenyAllAuthFilter : IAtomizerDashboardAuthorizationFilter


### PR DESCRIPTION
## Summary
- Add dashboard authorization helpers for ASP.NET Core policies, authenticated users, roles, claims, and async filters.
- Add opt-in Basic authentication with HTTPS required by default and async validator support.
- Allow the embedded dashboard SPA to send same-origin credentials plus configured request headers.

## Changes
- Replaced the raw authorization filter list with `DashboardAuthorizationOptions` while retaining custom filter support and localhost fallback.
- Added client request header configuration rendered into the embedded SPA and applied to dashboard API fetch calls.
- Documented production setup and covered authorization/client behavior with dashboard tests.