### PR TITLE
feat(dashboard): add job and schedule actions

### DIFF
--- a/src/Atomizer.Dashboard/Configuration/DashboardEndpointRouteExtensions.cs
+++ b/src/Atomizer.Dashboard/Configuration/DashboardEndpointRouteExtensions.cs
@@ -31,8 +31,32 @@ public static class DashboardEndpointRouteExtensions
             DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.GetByIdAsync(ctx))
         );
         endpoints.MapGet(
+            prefix + "/api/job-types",
+            DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.ListJobTypesAsync(ctx))
+        );
+        endpoints.MapPost(
+            prefix + "/api/jobs/trigger",
+            DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.TriggerAsync(ctx))
+        );
+        endpoints.MapPost(
+            prefix + "/api/jobs/{id:guid}/retry",
+            DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.RetryAsync(ctx))
+        );
+        endpoints.MapPost(
+            prefix + "/api/jobs/{id:guid}/cancel",
+            DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.CancelAsync(ctx))
+        );
+        endpoints.MapGet(
             prefix + "/api/schedules",
             DashboardAuthorizationFilter.Wrap<SchedulesEndpointHandler>((handler, ctx) => handler.ListAsync(ctx))
+        );
+        endpoints.MapPost(
+            prefix + "/api/schedules/{id:guid}/enabled",
+            DashboardAuthorizationFilter.Wrap<SchedulesEndpointHandler>((handler, ctx) => handler.SetEnabledAsync(ctx))
+        );
+        endpoints.MapPost(
+            prefix + "/api/schedules/{id:guid}/run-now",
+            DashboardAuthorizationFilter.Wrap<SchedulesEndpointHandler>((handler, ctx) => handler.RunNowAsync(ctx))
         );
         endpoints.MapGet(
             prefix + "/api/queues/stats",

--- a/src/Atomizer.Dashboard/Configuration/DashboardServiceCollectionExtensions.cs
+++ b/src/Atomizer.Dashboard/Configuration/DashboardServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Atomizer.Dashboard.Configuration;
 using Atomizer.Dashboard.Endpoints;
+using Atomizer.Dashboard.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -24,6 +25,7 @@ public static class DashboardServiceCollectionExtensions
     )
     {
         services.AddOptions<DashboardOptions>().Configure(configure ?? (_ => { }));
+        services.TryAddScoped<DashboardCommandService>();
         services.TryAddScoped<JobsEndpointHandler>();
         services.TryAddScoped<SchedulesEndpointHandler>();
         services.TryAddScoped<QueueStatsEndpointHandler>();

--- a/src/Atomizer.Dashboard/Contracts/DashboardActionDtos.cs
+++ b/src/Atomizer.Dashboard/Contracts/DashboardActionDtos.cs
@@ -1,0 +1,43 @@
+namespace Atomizer.Dashboard.Contracts;
+
+internal sealed class JobActionResponse
+{
+    public Guid JobId { get; init; }
+    public Guid? SourceJobId { get; init; }
+    public string Status { get; init; } = string.Empty;
+
+    internal static JobActionResponse From(AtomizerJob job, Guid? sourceJobId = null) =>
+        new()
+        {
+            JobId = job.Id,
+            SourceJobId = sourceJobId,
+            Status = job.Status.ToString(),
+        };
+}
+
+internal sealed class ScheduleActionResponse
+{
+    public ScheduleDto Schedule { get; init; } = new();
+
+    internal static ScheduleActionResponse From(AtomizerSchedule schedule) =>
+        new() { Schedule = ScheduleDto.From(schedule) };
+}
+
+internal sealed class JobTypeOptionDto
+{
+    public string Id { get; init; } = string.Empty;
+    public string PayloadTypeName { get; init; } = string.Empty;
+    public string PayloadTypeFullName { get; init; } = string.Empty;
+}
+
+internal sealed class SetScheduleEnabledRequest
+{
+    public bool Enabled { get; init; }
+}
+
+internal sealed class TriggerJobRequest
+{
+    public string PayloadTypeId { get; init; } = string.Empty;
+    public string QueueKey { get; init; } = string.Empty;
+    public string Payload { get; init; } = string.Empty;
+}

--- a/src/Atomizer.Dashboard/Contracts/JobDetailDto.cs
+++ b/src/Atomizer.Dashboard/Contracts/JobDetailDto.cs
@@ -8,6 +8,7 @@ internal sealed class JobDetailDto
     public string Status { get; init; } = string.Empty;
     public int Attempts { get; init; }
     public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
     public DateTimeOffset ScheduledAt { get; init; }
     public DateTimeOffset? CompletedAt { get; init; }
     public DateTimeOffset? FailedAt { get; init; }
@@ -25,6 +26,7 @@ internal sealed class JobDetailDto
             Status = job.Status.ToString(),
             Attempts = job.Attempts,
             CreatedAt = job.CreatedAt,
+            UpdatedAt = job.UpdatedAt,
             ScheduledAt = job.ScheduledAt,
             CompletedAt = job.CompletedAt,
             FailedAt = job.FailedAt,

--- a/src/Atomizer.Dashboard/Contracts/JobDto.cs
+++ b/src/Atomizer.Dashboard/Contracts/JobDto.cs
@@ -8,6 +8,7 @@ internal sealed class JobDto
     public string Status { get; init; } = string.Empty;
     public int Attempts { get; init; }
     public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
     public DateTimeOffset ScheduledAt { get; init; }
     public DateTimeOffset? CompletedAt { get; init; }
     public DateTimeOffset? FailedAt { get; init; }
@@ -23,6 +24,7 @@ internal sealed class JobDto
             Status = job.Status.ToString(),
             Attempts = job.Attempts,
             CreatedAt = job.CreatedAt,
+            UpdatedAt = job.UpdatedAt,
             ScheduledAt = job.ScheduledAt,
             CompletedAt = job.CompletedAt,
             FailedAt = job.FailedAt,

--- a/src/Atomizer.Dashboard/Contracts/QueueStatsResponse.cs
+++ b/src/Atomizer.Dashboard/Contracts/QueueStatsResponse.cs
@@ -14,6 +14,7 @@ internal sealed class QueueStatsDto
     public int Processing { get; init; }
     public int Completed { get; init; }
     public int Failed { get; init; }
+    public int Cancelled { get; init; }
 
     internal static QueueStatsDto From(QueueStats s) =>
         new()
@@ -23,5 +24,6 @@ internal sealed class QueueStatsDto
             Processing = s.Processing,
             Completed = s.Completed,
             Failed = s.Failed,
+            Cancelled = s.Cancelled,
         };
 }

--- a/src/Atomizer.Dashboard/Endpoints/JobsEndpointHandler.cs
+++ b/src/Atomizer.Dashboard/Endpoints/JobsEndpointHandler.cs
@@ -1,6 +1,7 @@
 using Atomizer.Abstractions;
 using Atomizer.Dashboard.Configuration;
 using Atomizer.Dashboard.Contracts;
+using Atomizer.Dashboard.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 
@@ -9,11 +10,17 @@ namespace Atomizer.Dashboard.Endpoints;
 internal sealed class JobsEndpointHandler
 {
     private readonly DashboardOptions _options;
+    private readonly DashboardCommandService _commands;
     private readonly IAtomizerStorage _storage;
 
-    public JobsEndpointHandler(IAtomizerStorage storage, IOptions<DashboardOptions> options)
+    public JobsEndpointHandler(
+        IAtomizerStorage storage,
+        DashboardCommandService commands,
+        IOptions<DashboardOptions> options
+    )
     {
         _storage = storage;
+        _commands = commands;
         _options = options.Value;
     }
 
@@ -76,5 +83,67 @@ internal sealed class JobsEndpointHandler
         }
 
         await DashboardJsonResponse.WriteAsync(context, JobDetailDto.FromDetail(job), context.RequestAborted);
+    }
+
+    public async Task ListJobTypesAsync(HttpContext context)
+    {
+        await DashboardJsonResponse.WriteAsync(context, _commands.GetJobTypeOptions(), context.RequestAborted);
+    }
+
+    public async Task RetryAsync(HttpContext context)
+    {
+        if (!TryGetJobId(context, out var id))
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        var result = await _commands.RetryJobAsync(id, context.RequestAborted);
+        await WriteCommandResultAsync(context, result);
+    }
+
+    public async Task CancelAsync(HttpContext context)
+    {
+        if (!TryGetJobId(context, out var id))
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        var result = await _commands.CancelJobAsync(id, context.RequestAborted);
+        await WriteCommandResultAsync(context, result);
+    }
+
+    public async Task TriggerAsync(HttpContext context)
+    {
+        var request = await context.Request.ReadFromJsonAsync<TriggerJobRequest>(
+            DashboardJsonOptions.CamelCase,
+            context.RequestAborted
+        );
+
+        if (request is null)
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        var result = await _commands.TriggerJobAsync(request, context.RequestAborted);
+        await WriteCommandResultAsync(context, result);
+    }
+
+    private static bool TryGetJobId(HttpContext context, out Guid id) =>
+        Guid.TryParse(context.Request.RouteValues["id"]?.ToString(), out id);
+
+    private static async Task WriteCommandResultAsync<T>(HttpContext context, DashboardCommandResult<T> result)
+    {
+        context.Response.StatusCode = result.StatusCode;
+        if (result.Value is not null)
+        {
+            await DashboardJsonResponse.WriteAsync(context, result.Value, context.RequestAborted);
+        }
+        else if (result.Message is not null)
+        {
+            await DashboardJsonResponse.WriteAsync(context, new { error = result.Message }, context.RequestAborted);
+        }
     }
 }

--- a/src/Atomizer.Dashboard/Endpoints/JobsEndpointHandler.cs
+++ b/src/Atomizer.Dashboard/Endpoints/JobsEndpointHandler.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Atomizer.Abstractions;
 using Atomizer.Dashboard.Configuration;
 using Atomizer.Dashboard.Contracts;
@@ -116,14 +117,23 @@ internal sealed class JobsEndpointHandler
 
     public async Task TriggerAsync(HttpContext context)
     {
-        var request = await context.Request.ReadFromJsonAsync<TriggerJobRequest>(
-            DashboardJsonOptions.CamelCase,
-            context.RequestAborted
-        );
+        TriggerJobRequest? request;
+        try
+        {
+            request = await context.Request.ReadFromJsonAsync<TriggerJobRequest>(
+                DashboardJsonOptions.CamelCase,
+                context.RequestAborted
+            );
+        }
+        catch (JsonException)
+        {
+            await WriteBadRequestAsync(context, "Malformed JSON request body.");
+            return;
+        }
 
         if (request is null)
         {
-            context.Response.StatusCode = 400;
+            await WriteBadRequestAsync(context, "Request body is required.");
             return;
         }
 
@@ -133,6 +143,12 @@ internal sealed class JobsEndpointHandler
 
     private static bool TryGetJobId(HttpContext context, out Guid id) =>
         Guid.TryParse(context.Request.RouteValues["id"]?.ToString(), out id);
+
+    private static Task WriteBadRequestAsync(HttpContext context, string message)
+    {
+        context.Response.StatusCode = 400;
+        return DashboardJsonResponse.WriteAsync(context, new { error = message }, context.RequestAborted);
+    }
 
     private static async Task WriteCommandResultAsync<T>(HttpContext context, DashboardCommandResult<T> result)
     {

--- a/src/Atomizer.Dashboard/Endpoints/SchedulesEndpointHandler.cs
+++ b/src/Atomizer.Dashboard/Endpoints/SchedulesEndpointHandler.cs
@@ -1,5 +1,6 @@
 using Atomizer.Abstractions;
 using Atomizer.Dashboard.Contracts;
+using Atomizer.Dashboard.Services;
 using Microsoft.AspNetCore.Http;
 
 namespace Atomizer.Dashboard.Endpoints;
@@ -7,10 +8,12 @@ namespace Atomizer.Dashboard.Endpoints;
 internal sealed class SchedulesEndpointHandler
 {
     private readonly IAtomizerStorage _storage;
+    private readonly DashboardCommandService _commands;
 
-    public SchedulesEndpointHandler(IAtomizerStorage storage)
+    public SchedulesEndpointHandler(IAtomizerStorage storage, DashboardCommandService commands)
     {
         _storage = storage;
+        _commands = commands;
     }
 
     public async Task ListAsync(HttpContext context)
@@ -21,5 +24,53 @@ internal sealed class SchedulesEndpointHandler
             schedules.Select(ScheduleDto.From).ToList(),
             context.RequestAborted
         );
+    }
+
+    public async Task SetEnabledAsync(HttpContext context)
+    {
+        if (!Guid.TryParse(context.Request.RouteValues["id"]?.ToString(), out var id))
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        var request = await context.Request.ReadFromJsonAsync<SetScheduleEnabledRequest>(
+            DashboardJsonOptions.CamelCase,
+            context.RequestAborted
+        );
+
+        if (request is null)
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        var result = await _commands.SetScheduleEnabledAsync(id, request.Enabled, context.RequestAborted);
+        await WriteCommandResultAsync(context, result);
+    }
+
+    public async Task RunNowAsync(HttpContext context)
+    {
+        if (!Guid.TryParse(context.Request.RouteValues["id"]?.ToString(), out var id))
+        {
+            context.Response.StatusCode = 400;
+            return;
+        }
+
+        var result = await _commands.RunScheduleNowAsync(id, context.RequestAborted);
+        await WriteCommandResultAsync(context, result);
+    }
+
+    private static async Task WriteCommandResultAsync<T>(HttpContext context, DashboardCommandResult<T> result)
+    {
+        context.Response.StatusCode = result.StatusCode;
+        if (result.Value is not null)
+        {
+            await DashboardJsonResponse.WriteAsync(context, result.Value, context.RequestAborted);
+        }
+        else if (result.Message is not null)
+        {
+            await DashboardJsonResponse.WriteAsync(context, new { error = result.Message }, context.RequestAborted);
+        }
     }
 }

--- a/src/Atomizer.Dashboard/Services/DashboardCommandResult.cs
+++ b/src/Atomizer.Dashboard/Services/DashboardCommandResult.cs
@@ -1,0 +1,23 @@
+namespace Atomizer.Dashboard.Services;
+
+internal sealed class DashboardCommandResult<T>
+{
+    private DashboardCommandResult(int statusCode, T? value, string? message)
+    {
+        StatusCode = statusCode;
+        Value = value;
+        Message = message;
+    }
+
+    public int StatusCode { get; }
+    public T? Value { get; }
+    public string? Message { get; }
+
+    public static DashboardCommandResult<T> Ok(T value) => new(200, value, null);
+
+    public static DashboardCommandResult<T> BadRequest(string message) => new(400, default, message);
+
+    public static DashboardCommandResult<T> NotFound(string message) => new(404, default, message);
+
+    public static DashboardCommandResult<T> Conflict(string message) => new(409, default, message);
+}

--- a/src/Atomizer.Dashboard/Services/DashboardCommandService.cs
+++ b/src/Atomizer.Dashboard/Services/DashboardCommandService.cs
@@ -1,0 +1,218 @@
+using Atomizer.Abstractions;
+using Atomizer.Core;
+using Atomizer.Dashboard.Contracts;
+
+namespace Atomizer.Dashboard.Services;
+
+internal sealed class DashboardCommandService
+{
+    private readonly AtomizerOptions _atomizerOptions;
+    private readonly IAtomizerClock _clock;
+    private readonly IAtomizerJobSerializer _serializer;
+    private readonly IAtomizerStorage _storage;
+
+    public DashboardCommandService(
+        IAtomizerStorage storage,
+        IAtomizerClock clock,
+        IAtomizerJobSerializer serializer,
+        AtomizerOptions atomizerOptions
+    )
+    {
+        _storage = storage;
+        _clock = clock;
+        _serializer = serializer;
+        _atomizerOptions = atomizerOptions;
+    }
+
+    public IReadOnlyList<JobTypeOptionDto> GetJobTypeOptions()
+    {
+        return _atomizerOptions
+            .JobHandlers.Select(handler => handler.PayloadType)
+            .Where(payloadType => payloadType.AssemblyQualifiedName is not null)
+            .Distinct()
+            .OrderBy(payloadType => payloadType.FullName ?? payloadType.Name, StringComparer.Ordinal)
+            .Select(payloadType => new JobTypeOptionDto
+            {
+                Id = payloadType.AssemblyQualifiedName!,
+                PayloadTypeName = payloadType.Name,
+                PayloadTypeFullName = payloadType.FullName ?? payloadType.Name,
+            })
+            .ToList();
+    }
+
+    public async Task<DashboardCommandResult<JobActionResponse>> RetryJobAsync(
+        Guid jobId,
+        CancellationToken cancellationToken
+    )
+    {
+        var source = await _storage.GetJobByIdAsync(jobId, cancellationToken);
+        if (source is null)
+        {
+            return DashboardCommandResult<JobActionResponse>.NotFound("Job was not found.");
+        }
+
+        if (source.Status != AtomizerJobStatus.Failed)
+        {
+            return DashboardCommandResult<JobActionResponse>.Conflict("Only failed jobs can be retried.");
+        }
+
+        if (source.PayloadType is null)
+        {
+            return DashboardCommandResult<JobActionResponse>.Conflict("Job has no payload type.");
+        }
+
+        var now = _clock.UtcNow;
+        var retry = AtomizerJob.Create(
+            source.QueueKey,
+            source.PayloadType,
+            source.Payload,
+            now,
+            now,
+            source.RetryStrategy,
+            scheduleJobKey: source.ScheduleJobKey,
+            partitionKey: source.PartitionKey
+        );
+
+        await _storage.InsertAsync(retry, cancellationToken);
+        return DashboardCommandResult<JobActionResponse>.Ok(JobActionResponse.From(retry, source.Id));
+    }
+
+    public async Task<DashboardCommandResult<JobActionResponse>> CancelJobAsync(
+        Guid jobId,
+        CancellationToken cancellationToken
+    )
+    {
+        var job = await _storage.GetJobByIdAsync(jobId, cancellationToken);
+        if (job is null)
+        {
+            return DashboardCommandResult<JobActionResponse>.NotFound("Job was not found.");
+        }
+
+        if (job.Status != AtomizerJobStatus.Pending)
+        {
+            return DashboardCommandResult<JobActionResponse>.Conflict("Only pending jobs can be cancelled.");
+        }
+
+        job.Cancel(_clock.UtcNow);
+        await _storage.UpdateJobsAsync([job], cancellationToken);
+        return DashboardCommandResult<JobActionResponse>.Ok(JobActionResponse.From(job));
+    }
+
+    public async Task<DashboardCommandResult<JobActionResponse>> TriggerJobAsync(
+        TriggerJobRequest request,
+        CancellationToken cancellationToken
+    )
+    {
+        if (string.IsNullOrWhiteSpace(request.PayloadTypeId))
+        {
+            return DashboardCommandResult<JobActionResponse>.BadRequest("Payload type is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.QueueKey))
+        {
+            return DashboardCommandResult<JobActionResponse>.BadRequest("Queue key is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Payload))
+        {
+            return DashboardCommandResult<JobActionResponse>.BadRequest("Payload is required.");
+        }
+
+        var payloadType = _atomizerOptions
+            .JobHandlers.Select(handler => handler.PayloadType)
+            .FirstOrDefault(type => type.AssemblyQualifiedName == request.PayloadTypeId);
+
+        if (payloadType is null)
+        {
+            return DashboardCommandResult<JobActionResponse>.BadRequest("Payload type is not registered.");
+        }
+
+        try
+        {
+            _serializer.Deserialize(request.Payload, payloadType);
+        }
+        catch (Exception ex)
+        {
+            return DashboardCommandResult<JobActionResponse>.BadRequest(ex.Message);
+        }
+
+        QueueKey queueKey;
+        try
+        {
+            queueKey = new QueueKey(request.QueueKey);
+        }
+        catch (Exception ex)
+        {
+            return DashboardCommandResult<JobActionResponse>.BadRequest(ex.Message);
+        }
+
+        var now = _clock.UtcNow;
+        var job = AtomizerJob.Create(queueKey, payloadType, request.Payload, now, now);
+        await _storage.InsertAsync(job, cancellationToken);
+        return DashboardCommandResult<JobActionResponse>.Ok(JobActionResponse.From(job));
+    }
+
+    public async Task<DashboardCommandResult<ScheduleActionResponse>> SetScheduleEnabledAsync(
+        Guid scheduleId,
+        bool enabled,
+        CancellationToken cancellationToken
+    )
+    {
+        var schedule = await GetScheduleAsync(scheduleId, cancellationToken);
+        if (schedule is null)
+        {
+            return DashboardCommandResult<ScheduleActionResponse>.NotFound("Schedule was not found.");
+        }
+
+        var now = _clock.UtcNow;
+        if (enabled)
+        {
+            schedule.Enable(now);
+        }
+        else
+        {
+            schedule.Disable(now);
+        }
+
+        await _storage.UpdateSchedulesAsync([schedule], cancellationToken);
+        return DashboardCommandResult<ScheduleActionResponse>.Ok(ScheduleActionResponse.From(schedule));
+    }
+
+    public async Task<DashboardCommandResult<JobActionResponse>> RunScheduleNowAsync(
+        Guid scheduleId,
+        CancellationToken cancellationToken
+    )
+    {
+        var schedule = await GetScheduleAsync(scheduleId, cancellationToken);
+        if (schedule is null)
+        {
+            return DashboardCommandResult<JobActionResponse>.NotFound("Schedule was not found.");
+        }
+
+        if (schedule.PayloadType is null)
+        {
+            return DashboardCommandResult<JobActionResponse>.Conflict("Schedule has no payload type.");
+        }
+
+        var now = _clock.UtcNow;
+        var job = AtomizerJob.Create(
+            schedule.QueueKey,
+            schedule.PayloadType,
+            schedule.Payload,
+            now,
+            now,
+            schedule.RetryStrategy,
+            scheduleJobKey: schedule.JobKey,
+            partitionKey: schedule.PartitionKey
+        );
+
+        await _storage.InsertAsync(job, cancellationToken);
+        return DashboardCommandResult<JobActionResponse>.Ok(JobActionResponse.From(job));
+    }
+
+    private async Task<AtomizerSchedule?> GetScheduleAsync(Guid scheduleId, CancellationToken cancellationToken)
+    {
+        var schedules = await _storage.GetSchedulesAsync(cancellationToken);
+        return schedules.FirstOrDefault(schedule => schedule.Id == scheduleId);
+    }
+}

--- a/src/Atomizer.Dashboard/Services/DashboardCommandService.cs
+++ b/src/Atomizer.Dashboard/Services/DashboardCommandService.cs
@@ -93,7 +93,15 @@ internal sealed class DashboardCommandService
             return DashboardCommandResult<JobActionResponse>.Conflict("Only pending jobs can be cancelled.");
         }
 
-        job.Cancel(_clock.UtcNow);
+        try
+        {
+            job.Cancel(_clock.UtcNow);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return DashboardCommandResult<JobActionResponse>.Conflict(ex.Message);
+        }
+
         await _storage.UpdateJobsAsync([job], cancellationToken);
         return DashboardCommandResult<JobActionResponse>.Ok(JobActionResponse.From(job));
     }

--- a/src/Atomizer.Dashboard/frontend/src/api/client.ts
+++ b/src/Atomizer.Dashboard/frontend/src/api/client.ts
@@ -1,5 +1,16 @@
 import { apiRequestHeaders, routePrefix } from '../config';
-import type { PagedResponse, JobDto, JobDetailDto, ScheduleDto, QueueStatsResponse, ServerDto } from './types';
+import type {
+    PagedResponse,
+    JobDto,
+    JobDetailDto,
+    ScheduleDto,
+    QueueStatsResponse,
+    ServerDto,
+    JobTypeOption,
+    TriggerJobRequest,
+    JobActionResponse,
+    ScheduleActionResponse,
+} from './types';
 
 const baseUrl = `${window.location.origin}${routePrefix}/api`;
 
@@ -18,8 +29,24 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
         credentials: init?.credentials ?? 'same-origin',
         headers: buildHeaders(init?.headers),
     });
-    if (!res.ok) throw new Error(`${res.status} ${res.statusText} — ${path}`);
+    if (!res.ok) throw new Error(await readErrorMessage(res, path));
     return res.json() as Promise<T>;
+}
+
+async function readErrorMessage(res: Response, path: string): Promise<string> {
+    const fallback = `${res.status} ${res.statusText} — ${path}`;
+    try {
+        const contentType = res.headers.get('content-type') ?? '';
+        if (contentType.includes('application/json')) {
+            const body = (await res.json()) as { error?: unknown };
+            return typeof body.error === 'string' && body.error.length > 0 ? body.error : fallback;
+        }
+
+        const text = await res.text();
+        return text.trim().length > 0 ? text.trim() : fallback;
+    } catch {
+        return fallback;
+    }
 }
 
 function buildQuery(params: Record<string, string | string[] | number | undefined>): string {
@@ -41,7 +68,23 @@ export const api = {
         return request<PagedResponse<JobDto>>(`/jobs${qs ? `?${qs}` : ''}`);
     },
     getJob: (id: string) => request<JobDetailDto>(`/jobs/${id}`),
+    getJobTypes: () => request<JobTypeOption[]>('/job-types'),
+    triggerJob: (body: TriggerJobRequest) =>
+        request<JobActionResponse>('/jobs/trigger', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        }),
+    retryJob: (id: string) => request<JobActionResponse>(`/jobs/${id}/retry`, { method: 'POST' }),
+    cancelJob: (id: string) => request<JobActionResponse>(`/jobs/${id}/cancel`, { method: 'POST' }),
     getSchedules: () => request<ScheduleDto[]>('/schedules'),
+    setScheduleEnabled: (id: string, enabled: boolean) =>
+        request<ScheduleActionResponse>(`/schedules/${id}/enabled`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ enabled }),
+        }),
+    runScheduleNow: (id: string) => request<JobActionResponse>(`/schedules/${id}/run-now`, { method: 'POST' }),
     getQueueStats: () => request<QueueStatsResponse>('/queues/stats'),
     getServers: () => request<ServerDto[]>('/servers'),
 };

--- a/src/Atomizer.Dashboard/frontend/src/api/hooks.ts
+++ b/src/Atomizer.Dashboard/frontend/src/api/hooks.ts
@@ -1,7 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { api } from './client';
 import { statsRefreshMs, jobsRefreshMs } from '../config';
-import type { JobDto, JobDetailDto, ScheduleDto, QueueStatsResponse, ServerDto, PagedResponse } from './types';
+import type {
+    JobDto,
+    JobDetailDto,
+    ScheduleDto,
+    QueueStatsResponse,
+    ServerDto,
+    PagedResponse,
+    JobTypeOption,
+} from './types';
 
 export interface JobFilters {
     status?: string[];
@@ -26,6 +34,13 @@ export function useJob(id: string) {
         queryKey: ['job', id],
         queryFn: () => api.getJob(id),
         enabled: !!id,
+    });
+}
+
+export function useJobTypes() {
+    return useQuery<JobTypeOption[]>({
+        queryKey: ['jobTypes'],
+        queryFn: api.getJobTypes,
     });
 }
 

--- a/src/Atomizer.Dashboard/frontend/src/api/types.ts
+++ b/src/Atomizer.Dashboard/frontend/src/api/types.ts
@@ -11,15 +11,17 @@ export interface JobStatusCounts {
     processing: number;
     completed: number;
     failed: number;
+    cancelled: number;
 }
 
 export interface JobDto {
     id: string;
     queueKey: string;
     payloadTypeName: string;
-    status: 'Pending' | 'Processing' | 'Completed' | 'Failed';
+    status: 'Pending' | 'Processing' | 'Completed' | 'Failed' | 'Cancelled';
     attempts: number;
     createdAt: string;
+    updatedAt: string;
     scheduledAt: string | null;
     completedAt: string | null;
     failedAt: string | null;
@@ -53,6 +55,28 @@ export interface ScheduleDto {
     misfirePolicy: string;
 }
 
+export interface JobTypeOption {
+    id: string;
+    payloadTypeName: string;
+    payloadTypeFullName: string;
+}
+
+export interface TriggerJobRequest {
+    payloadTypeId: string;
+    queueKey: string;
+    payload: string;
+}
+
+export interface JobActionResponse {
+    jobId: string;
+    sourceJobId: string | null;
+    status: 'Pending' | 'Processing' | 'Completed' | 'Failed' | 'Cancelled';
+}
+
+export interface ScheduleActionResponse {
+    schedule: ScheduleDto;
+}
+
 export interface QueueStatsResponse {
     queues: QueueStatsDto[];
 }
@@ -63,6 +87,7 @@ export interface QueueStatsDto {
     processing: number;
     completed: number;
     failed: number;
+    cancelled: number;
 }
 
 export interface ServerDto {

--- a/src/Atomizer.Dashboard/frontend/src/components/DashboardUi.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/components/DashboardUi.tsx
@@ -18,6 +18,7 @@ const statusTones: Record<string, Tone> = {
     Processing: 'blue',
     Completed: 'green',
     Failed: 'red',
+    Cancelled: 'slate',
     Enabled: 'green',
     Disabled: 'slate',
     Healthy: 'green',

--- a/src/Atomizer.Dashboard/frontend/src/index.css
+++ b/src/Atomizer.Dashboard/frontend/src/index.css
@@ -465,6 +465,10 @@ input:focus-visible {
     color: #fb7185;
 }
 
+.count-slate {
+    color: #94a3b8;
+}
+
 [data-theme="light"] .count-amber {
     color: #d97706;
 }
@@ -479,6 +483,10 @@ input:focus-visible {
 
 [data-theme="light"] .count-rose {
     color: #e11d48;
+}
+
+[data-theme="light"] .count-slate {
+    color: #475569;
 }
 
 .status-pill {

--- a/src/Atomizer.Dashboard/frontend/src/views/JobDetail.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/JobDetail.tsx
@@ -1,4 +1,6 @@
 import { Link, useParams } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '../api/client';
 import { useJob } from '../api/hooks';
 import { routePrefix } from '../config';
 import {
@@ -16,8 +18,15 @@ import { useNow } from '../hooks/useNow';
 
 export default function JobDetail() {
     const { id } = useParams<{ id: string }>();
+    const queryClient = useQueryClient();
     const now = useNow(15_000);
     const { data: job, isLoading, error } = useJob(id!);
+    const refreshJobQueries = () => {
+        queryClient.invalidateQueries({ queryKey: ['job', id] });
+        queryClient.invalidateQueries({ queryKey: ['jobs'] });
+    };
+    const retryMutation = useMutation({ mutationFn: api.retryJob, onSuccess: refreshJobQueries });
+    const cancelMutation = useMutation({ mutationFn: api.cancelJob, onSuccess: refreshJobQueries });
 
     if (isLoading) return <JobDetailSkeleton />;
     if (error || !job)
@@ -37,8 +46,10 @@ export default function JobDetail() {
         /* not valid JSON, show raw */
     }
 
-    const finalTimestamp = job.failedAt ?? job.completedAt ?? job.scheduledAt ?? job.createdAt;
-    const finalLabel = job.failedAt ? 'Failed' : job.completedAt ? 'Completed' : job.scheduledAt ? 'Scheduled' : 'Created';
+    const finalTimestamp =
+        job.status === 'Cancelled' ? job.updatedAt : job.failedAt ?? job.completedAt ?? job.scheduledAt ?? job.createdAt;
+    const finalLabel =
+        job.status === 'Cancelled' ? 'Cancelled' : job.failedAt ? 'Failed' : job.completedAt ? 'Completed' : job.scheduledAt ? 'Scheduled' : 'Created';
 
     return (
         <div className="space-y-6">
@@ -49,6 +60,26 @@ export default function JobDetail() {
                 actions={
                     <>
                         <StatusPill status={job.status} className="px-3 py-1.5 text-sm" />
+                        {job.status === 'Failed' && (
+                            <button
+                                type="button"
+                                className={ui.primaryButton}
+                                disabled={retryMutation.isPending}
+                                onClick={() => retryMutation.mutate(job.id)}
+                            >
+                                {retryMutation.isPending ? 'Retrying…' : 'Retry'}
+                            </button>
+                        )}
+                        {job.status === 'Pending' && (
+                            <button
+                                type="button"
+                                className={ui.secondaryButton}
+                                disabled={cancelMutation.isPending}
+                                onClick={() => cancelMutation.mutate(job.id)}
+                            >
+                                {cancelMutation.isPending ? 'Cancelling…' : 'Cancel'}
+                            </button>
+                        )}
                         <Link
                             to={`${routePrefix}/jobs`}
                             className={ui.secondaryButton}
@@ -58,6 +89,14 @@ export default function JobDetail() {
                     </>
                 }
             />
+
+            {(retryMutation.error || cancelMutation.error) && (
+                <Panel className="p-5">
+                    <p className="danger-text text-sm font-medium">
+                        {(retryMutation.error ?? cancelMutation.error)?.message}
+                    </p>
+                </Panel>
+            )}
 
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                 <MetricCard label="Queue" value={job.queueKey} helper="Assigned queue" tone="blue" />
@@ -78,7 +117,7 @@ export default function JobDetail() {
                     label={finalLabel}
                     value={<RelativeTime value={finalTimestamp} now={now} />}
                     helper="Most relevant transition"
-                    tone={job.status === 'Failed' ? 'red' : job.status === 'Completed' ? 'green' : 'purple'}
+                    tone={job.status === 'Failed' ? 'red' : job.status === 'Completed' ? 'green' : job.status === 'Cancelled' ? 'slate' : 'purple'}
                 />
             </div>
 
@@ -92,6 +131,12 @@ export default function JobDetail() {
                     <TimelineItem label="Scheduled" value={job.scheduledAt} now={now} empty="Not scheduled" />
                     <TimelineItem label="Completed" value={job.completedAt} now={now} empty="Not completed" />
                     <TimelineItem label="Failed" value={job.failedAt} now={now} empty="No failure recorded" />
+                    <TimelineItem
+                        label="Updated"
+                        value={job.updatedAt}
+                        now={now}
+                        empty="No update recorded"
+                    />
                 </div>
             </Panel>
 

--- a/src/Atomizer.Dashboard/frontend/src/views/JobsList.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/JobsList.tsx
@@ -1,7 +1,9 @@
-import type { KeyboardEvent } from 'react';
+import type { FormEvent, KeyboardEvent, MouseEvent } from 'react';
 import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useJobs, type JobFilters } from '../api/hooks';
+import { api } from '../api/client';
+import { useJobs, useJobTypes, type JobFilters } from '../api/hooks';
 import { routePrefix, jobsRefreshMs } from '../config';
 import type { JobDto } from '../api/types';
 import {
@@ -21,8 +23,9 @@ import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { useNow } from '../hooks/useNow';
 import { getJobPageWindow } from './jobsPagination';
 
-const STATUS_OPTIONS = ['Pending', 'Processing', 'Completed', 'Failed'] as const;
+const STATUS_OPTIONS = ['Pending', 'Processing', 'Completed', 'Failed', 'Cancelled'] as const;
 const PAGE_SIZE = 20;
+const QueueKeyDefault = 'default';
 const TIME_FILTERS = [
     { key: 'all', label: 'All time', getFrom: () => undefined },
     { key: '15m', label: '15m', getFrom: () => new Date(Date.now() - 15 * 60 * 1000).toISOString() },
@@ -34,7 +37,12 @@ const TIME_FILTERS = [
 export default function JobsList() {
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const now = useNow(1_000);
+    const [isTriggerOpen, setIsTriggerOpen] = useState(false);
+    const [triggerPayloadTypeId, setTriggerPayloadTypeId] = useState('');
+    const [triggerQueueKey, setTriggerQueueKey] = useState(QueueKeyDefault);
+    const [triggerPayload, setTriggerPayload] = useState('{\n  "message": ""\n}');
     const [timeFilter, setTimeFilter] = useState<(typeof TIME_FILTERS)[number]['key']>('all');
     const [filters, setFilters] = useState<JobFilters>(() => ({
         skip: 0,
@@ -48,7 +56,23 @@ export default function JobsList() {
     const debouncedQueueSearch = useDebouncedValue(queueSearch, 300);
     const debouncedPayloadSearch = useDebouncedValue(payloadSearch, 300);
     const { data, isLoading, error, refetch, dataUpdatedAt, isFetching } = useJobs(filters);
-    const counts = data?.statusCounts ?? { pending: 0, processing: 0, completed: 0, failed: 0 };
+    const { data: jobTypes = [] } = useJobTypes();
+    const counts = data?.statusCounts ?? { pending: 0, processing: 0, completed: 0, failed: 0, cancelled: 0 };
+    const retryMutation = useMutation({
+        mutationFn: api.retryJob,
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ['jobs'] }),
+    });
+    const cancelMutation = useMutation({
+        mutationFn: api.cancelJob,
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ['jobs'] }),
+    });
+    const triggerMutation = useMutation({
+        mutationFn: api.triggerJob,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['jobs'] });
+            setIsTriggerOpen(false);
+        },
+    });
 
     const take = filters.take ?? PAGE_SIZE;
     const currentPage = Math.floor((filters.skip ?? 0) / take) + 1;
@@ -67,11 +91,29 @@ export default function JobsList() {
         }));
     }, [debouncedPayloadSearch, debouncedQueueSearch]);
 
+    useEffect(() => {
+        if (!triggerPayloadTypeId && jobTypes.length > 0) {
+            setTriggerPayloadTypeId(jobTypes[0].id);
+        }
+    }, [jobTypes, triggerPayloadTypeId]);
+
     const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, jobId: string) => {
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
             openJob(jobId);
         }
+    };
+
+    const stopRowAction = (event: MouseEvent<HTMLButtonElement>) => event.stopPropagation();
+    const stopRowKeyboardAction = (event: KeyboardEvent<HTMLButtonElement>) => event.stopPropagation();
+
+    const submitTriggerJob = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        triggerMutation.mutate({
+            payloadTypeId: triggerPayloadTypeId,
+            queueKey: triggerQueueKey,
+            payload: triggerPayload,
+        });
     };
 
     const applyTimeFilter = (key: (typeof TIME_FILTERS)[number]['key']) => {
@@ -105,9 +147,79 @@ export default function JobsList() {
                         >
                             {isFetching ? 'Refreshing…' : 'Refresh'}
                         </button>
+                        <button
+                            onClick={() => setIsTriggerOpen(open => !open)}
+                            className={ui.secondaryButton}
+                            disabled={jobTypes.length === 0}
+                        >
+                            Trigger job
+                        </button>
                     </>
                 }
             />
+
+            {isTriggerOpen && (
+                <Panel>
+                    <form onSubmit={submitTriggerJob} className="grid gap-4 p-5 xl:grid-cols-[minmax(0,1fr)_12rem]">
+                        <label className="block">
+                            <span className={ui.fieldLabel}>Payload type</span>
+                            <select
+                                className={ui.input}
+                                value={triggerPayloadTypeId}
+                                onChange={event => setTriggerPayloadTypeId(event.target.value)}
+                            >
+                                {jobTypes.map(option => (
+                                    <option key={option.id} value={option.id}>
+                                        {option.payloadTypeFullName}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <label className="block">
+                            <span className={ui.fieldLabel}>Queue</span>
+                            <input
+                                type="text"
+                                className={ui.input}
+                                value={triggerQueueKey}
+                                onChange={event => setTriggerQueueKey(event.target.value)}
+                            />
+                        </label>
+
+                        <label className="block xl:col-span-2">
+                            <span className={ui.fieldLabel}>Payload JSON</span>
+                            <textarea
+                                className="input-field mt-2 h-44 w-full rounded-2xl border px-4 py-3 font-mono text-sm outline-none transition"
+                                value={triggerPayload}
+                                onChange={event => setTriggerPayload(event.target.value)}
+                            />
+                        </label>
+
+                        {triggerMutation.error && (
+                            <div className="danger-text text-sm font-medium xl:col-span-2">
+                                {triggerMutation.error.message}
+                            </div>
+                        )}
+
+                        <div className="flex flex-wrap gap-2 xl:col-span-2">
+                            <button
+                                type="submit"
+                                className={ui.primaryButton}
+                                disabled={triggerMutation.isPending || !triggerPayloadTypeId}
+                            >
+                                {triggerMutation.isPending ? 'Triggering…' : 'Trigger'}
+                            </button>
+                            <button
+                                type="button"
+                                className={ui.secondaryButton}
+                                onClick={() => setIsTriggerOpen(false)}
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </form>
+                </Panel>
+            )}
 
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
                 {isLoading ? (
@@ -232,8 +344,13 @@ export default function JobsList() {
                     </div>
                 </div>
 
-                {isLoading && <TableSkeleton columns={6} rows={6} />}
+                {isLoading && <TableSkeleton columns={7} rows={6} />}
                 {error && <div className={ui.error}>Error loading jobs.</div>}
+                {(retryMutation.error || cancelMutation.error) && (
+                    <div className="danger-text border-t border-[var(--border-soft)] px-5 py-3 text-sm font-medium">
+                        {(retryMutation.error ?? cancelMutation.error)?.message}
+                    </div>
+                )}
                 {data && (
                     <>
                         <div className="overflow-x-auto">
@@ -246,6 +363,7 @@ export default function JobsList() {
                                         <th className="px-5 py-4 font-semibold">Attempts</th>
                                         <th className="px-5 py-4 font-semibold">Timing</th>
                                         <th className="px-5 py-4 font-semibold">Payload</th>
+                                        <th className="px-5 py-4 font-semibold">Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody className={ui.tableBody}>
@@ -295,6 +413,41 @@ export default function JobsList() {
                                                     Open details →
                                                 </div>
                                             </td>
+                                            <td className="px-5 py-4">
+                                                <div className="flex flex-wrap gap-2">
+                                                    {job.status === 'Failed' && (
+                                                        <button
+                                                            type="button"
+                                                            className={ui.smallButton}
+                                                            disabled={retryMutation.isPending}
+                                                            onKeyDown={stopRowKeyboardAction}
+                                                            onClick={event => {
+                                                                stopRowAction(event);
+                                                                retryMutation.mutate(job.id);
+                                                            }}
+                                                        >
+                                                            Retry
+                                                        </button>
+                                                    )}
+                                                    {job.status === 'Pending' && (
+                                                        <button
+                                                            type="button"
+                                                            className={ui.smallButton}
+                                                            disabled={cancelMutation.isPending}
+                                                            onKeyDown={stopRowKeyboardAction}
+                                                            onClick={event => {
+                                                                stopRowAction(event);
+                                                                cancelMutation.mutate(job.id);
+                                                            }}
+                                                        >
+                                                            Cancel
+                                                        </button>
+                                                    )}
+                                                    {job.status !== 'Failed' && job.status !== 'Pending' && (
+                                                        <span className={cx(ui.muted, 'text-xs')}>No action</span>
+                                                    )}
+                                                </div>
+                                            </td>
                                         </tr>
                                     ))}
                                 </tbody>
@@ -339,6 +492,14 @@ export default function JobsList() {
 }
 
 function JobTiming({ job, now }: { job: JobDto; now: number }) {
+    if (job.status === 'Cancelled') {
+        return (
+            <span>
+                Cancelled <RelativeTime value={job.updatedAt} now={now} />
+            </span>
+        );
+    }
+
     if (job.failedAt) {
         return (
             <span>

--- a/src/Atomizer.Dashboard/frontend/src/views/QueueStats.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/QueueStats.tsx
@@ -25,8 +25,9 @@ export default function QueueStats() {
             processing: acc.processing + queue.processing,
             completed: acc.completed + queue.completed,
             failed: acc.failed + queue.failed,
+            cancelled: acc.cancelled + queue.cancelled,
         }),
-        { pending: 0, processing: 0, completed: 0, failed: 0 },
+        { pending: 0, processing: 0, completed: 0, failed: 0, cancelled: 0 },
     );
 
     const openQueueJobs = (queueKey: string) =>
@@ -74,7 +75,7 @@ export default function QueueStats() {
                     <p className={ui.sectionDescription}>Counts are grouped by queue and job status.</p>
                 </div>
 
-                {isLoading && <TableSkeleton columns={7} rows={5} />}
+                {isLoading && <TableSkeleton columns={8} rows={5} />}
                 {error && <div className={ui.error}>Error loading queue stats.</div>}
                 {data && (
                     <>
@@ -88,12 +89,18 @@ export default function QueueStats() {
                                         <th className="px-5 py-4 font-semibold">Processing</th>
                                         <th className="px-5 py-4 font-semibold">Completed</th>
                                         <th className="px-5 py-4 font-semibold">Failed</th>
+                                        <th className="px-5 py-4 font-semibold">Cancelled</th>
                                         <th className="px-5 py-4 font-semibold">Work mix</th>
                                     </tr>
                                 </thead>
                                 <tbody className={ui.tableBody}>
                                     {queues.map(queue => {
-                                        const total = queue.pending + queue.processing + queue.completed + queue.failed;
+                                        const total =
+                                            queue.pending +
+                                            queue.processing +
+                                            queue.completed +
+                                            queue.failed +
+                                            queue.cancelled;
                                         const hasBacklog = queue.pending > 0;
                                         const hasFailures = queue.failed > 0;
                                         const state = hasFailures ? 'Attention' : hasBacklog ? 'Backlog' : queue.processing > 0 ? 'Active' : 'Idle';
@@ -124,11 +131,13 @@ export default function QueueStats() {
                                                 <CountCell value={queue.processing} tone="count-sky" />
                                                 <CountCell value={queue.completed} tone="count-emerald" />
                                                 <CountCell value={queue.failed} tone="count-rose" />
+                                                <CountCell value={queue.cancelled} tone="count-slate" />
                                                 <td className="px-5 py-4">
                                                     <div className="flex h-2 w-40 overflow-hidden rounded-full bg-[var(--chip)]">
                                                         <WorkMixSegment value={queue.pending} total={total} className="bg-amber-400" />
                                                         <WorkMixSegment value={queue.processing} total={total} className="bg-sky-400" />
                                                         <WorkMixSegment value={queue.failed} total={total} className="bg-rose-400" />
+                                                        <WorkMixSegment value={queue.cancelled} total={total} className="bg-slate-400" />
                                                         <WorkMixSegment value={queue.completed} total={total} className="bg-emerald-400" />
                                                     </div>
                                                     <div className={cx(ui.soft, 'mt-1 text-xs')}>{formatNumber(total)} total</div>

--- a/src/Atomizer.Dashboard/frontend/src/views/SchedulesList.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/SchedulesList.tsx
@@ -1,5 +1,7 @@
-import type { KeyboardEvent } from 'react';
+import type { KeyboardEvent, MouseEvent } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import { api } from '../api/client';
 import { useSchedules } from '../api/hooks';
 import { routePrefix, statsRefreshMs } from '../config';
 import {
@@ -20,7 +22,21 @@ import { useNow } from '../hooks/useNow';
 export default function SchedulesList() {
     const { data, isLoading, error, dataUpdatedAt } = useSchedules();
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const now = useNow(1_000);
+    const invalidateScheduleActions = () => {
+        queryClient.invalidateQueries({ queryKey: ['schedules'] });
+        queryClient.invalidateQueries({ queryKey: ['jobs'] });
+        queryClient.invalidateQueries({ queryKey: ['queueStats'] });
+    };
+    const toggleMutation = useMutation({
+        mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) => api.setScheduleEnabled(id, enabled),
+        onSuccess: invalidateScheduleActions,
+    });
+    const runNowMutation = useMutation({
+        mutationFn: api.runScheduleNow,
+        onSuccess: invalidateScheduleActions,
+    });
     const schedules = data ?? [];
     const enabled = schedules.filter(schedule => schedule.enabled).length;
     const paused = schedules.length - enabled;
@@ -45,6 +61,9 @@ export default function SchedulesList() {
             openScheduleJobs(queueKey, payloadTypeName);
         }
     };
+
+    const stopRowAction = (event: MouseEvent<HTMLButtonElement>) => event.stopPropagation();
+    const stopRowKeyboardAction = (event: KeyboardEvent<HTMLButtonElement>) => event.stopPropagation();
 
     return (
         <div className="space-y-6">
@@ -81,8 +100,13 @@ export default function SchedulesList() {
                     <p className={ui.sectionDescription}>Open a row to see jobs created by that queue and payload type.</p>
                 </div>
 
-                {isLoading && <TableSkeleton columns={8} rows={5} />}
+                {isLoading && <TableSkeleton columns={9} rows={5} />}
                 {error && <div className={ui.error}>Error loading schedules.</div>}
+                {(toggleMutation.error || runNowMutation.error) && (
+                    <div className="danger-text border-t border-[var(--border-soft)] px-5 py-3 text-sm font-medium">
+                        {(toggleMutation.error ?? runNowMutation.error)?.message}
+                    </div>
+                )}
                 {data && (
                     <>
                         <div className="overflow-x-auto">
@@ -97,6 +121,7 @@ export default function SchedulesList() {
                                         <th className="px-5 py-4 font-semibold">Last run</th>
                                         <th className="px-5 py-4 font-semibold">Misfire</th>
                                         <th className="px-5 py-4 font-semibold">State</th>
+                                        <th className="px-5 py-4 font-semibold">Actions</th>
                                     </tr>
                                 </thead>
                                 <tbody className={ui.tableBody}>
@@ -142,6 +167,37 @@ export default function SchedulesList() {
                                             <td className={cx(ui.muted, 'px-5 py-4')}>{schedule.misfirePolicy}</td>
                                             <td className="px-5 py-4">
                                                 <StatusPill status={schedule.enabled ? 'Enabled' : 'Disabled'} />
+                                            </td>
+                                            <td className="px-5 py-4">
+                                                <div className="flex flex-wrap gap-2">
+                                                    <button
+                                                        type="button"
+                                                        className={ui.smallButton}
+                                                        disabled={toggleMutation.isPending}
+                                                        onKeyDown={stopRowKeyboardAction}
+                                                        onClick={event => {
+                                                            stopRowAction(event);
+                                                            toggleMutation.mutate({
+                                                                id: schedule.id,
+                                                                enabled: !schedule.enabled,
+                                                            });
+                                                        }}
+                                                    >
+                                                        {schedule.enabled ? 'Disable' : 'Enable'}
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        className={ui.smallButton}
+                                                        disabled={runNowMutation.isPending}
+                                                        onKeyDown={stopRowKeyboardAction}
+                                                        onClick={event => {
+                                                            stopRowAction(event);
+                                                            runNowMutation.mutate(schedule.id);
+                                                        }}
+                                                    >
+                                                        Run now
+                                                    </button>
+                                                </div>
                                             </td>
                                         </tr>
                                     ))}

--- a/src/Atomizer.EntityFrameworkCore/Entities/AtomizerJobEntity.cs
+++ b/src/Atomizer.EntityFrameworkCore/Entities/AtomizerJobEntity.cs
@@ -79,6 +79,9 @@ public enum AtomizerEntityJobStatus
 
     /// <summary>The job failed and all retry attempts have been exhausted.</summary>
     Failed = 4,
+
+    /// <summary>The job was cancelled before processing.</summary>
+    Cancelled = 5,
 }
 
 /// <summary>

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/MySqlDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/MySqlDialect.cs
@@ -183,10 +183,8 @@ internal sealed class MySqlDialect(EntityMap jobs, EntityMap schedules) : BaseSq
                 {{_sTimeZone}} = VALUES({{_sTimeZone}}),
                 {{_sMisfirePolicy}} = VALUES({{_sMisfirePolicy}}),
                 {{_sMaxCatchUp}} = VALUES({{_sMaxCatchUp}}),
-                {{_sEnabled}} = VALUES({{_sEnabled}}),
                 {{_sPartitionKey}} = VALUES({{_sPartitionKey}}),
                 {{_sRetryIntervals}} = VALUES({{_sRetryIntervals}}),
-                {{_sNextRunAt}} = VALUES({{_sNextRunAt}}),
                 {{_sUpdatedAt}} = {15};
             """;
         return FormattableStringFactory.Create(

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/PostgreSqlDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/PostgreSqlDialect.cs
@@ -183,10 +183,8 @@ internal sealed class PostgreSqlDialect(EntityMap jobs, EntityMap schedules) : B
                 {{_sTimeZone}} = EXCLUDED.{{_sTimeZone}},
                 {{_sMisfirePolicy}} = EXCLUDED.{{_sMisfirePolicy}},
                 {{_sMaxCatchUp}} = EXCLUDED.{{_sMaxCatchUp}},
-                {{_sEnabled}} = EXCLUDED.{{_sEnabled}},
                 {{_sPartitionKey}} = EXCLUDED.{{_sPartitionKey}},
                 {{_sRetryIntervals}} = EXCLUDED.{{_sRetryIntervals}},
-                {{_sNextRunAt}} = EXCLUDED.{{_sNextRunAt}},
                 {{_sUpdatedAt}} = EXCLUDED.{{_sUpdatedAt}};
             """;
         return FormattableStringFactory.Create(

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/SqlServerDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/SqlServerDialect.cs
@@ -147,10 +147,8 @@ internal sealed class SqlServerDialect(EntityMap jobs, EntityMap schedules) : Ba
                 {{_sTimeZone}} = {5},
                 {{_sMisfirePolicy}} = {6},
                 {{_sMaxCatchUp}} = {7},
-                {{_sEnabled}} = {8},
                 {{_sPartitionKey}} = {9},
                 {{_sRetryIntervals}} = {10},
-                {{_sNextRunAt}} = {11},
                 {{_sUpdatedAt}} = {12}
             WHEN NOT MATCHED THEN INSERT (
                 {{_sId}},

--- a/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
+++ b/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
@@ -356,6 +356,7 @@ internal sealed class EntityFrameworkCoreStorage<TDbContext> : IAtomizerStorage
             Processing = counts.FirstOrDefault(c => c.Status == AtomizerEntityJobStatus.Processing)?.Count ?? 0,
             Completed = counts.FirstOrDefault(c => c.Status == AtomizerEntityJobStatus.Completed)?.Count ?? 0,
             Failed = counts.FirstOrDefault(c => c.Status == AtomizerEntityJobStatus.Failed)?.Count ?? 0,
+            Cancelled = counts.FirstOrDefault(c => c.Status == AtomizerEntityJobStatus.Cancelled)?.Count ?? 0,
         };
     }
 
@@ -435,6 +436,7 @@ internal sealed class EntityFrameworkCoreStorage<TDbContext> : IAtomizerStorage
                 Processing = g.Count(e => e.Status == AtomizerEntityJobStatus.Processing),
                 Completed = g.Count(e => e.Status == AtomizerEntityJobStatus.Completed),
                 Failed = g.Count(e => e.Status == AtomizerEntityJobStatus.Failed),
+                Cancelled = g.Count(e => e.Status == AtomizerEntityJobStatus.Cancelled),
             })
             .ToListAsync(cancellationToken);
 
@@ -446,6 +448,7 @@ internal sealed class EntityFrameworkCoreStorage<TDbContext> : IAtomizerStorage
                 Processing = s.Processing,
                 Completed = s.Completed,
                 Failed = s.Failed,
+                Cancelled = s.Cancelled,
             })
             .ToList();
     }

--- a/src/Atomizer/Abstractions/JobStatusCounts.cs
+++ b/src/Atomizer/Abstractions/JobStatusCounts.cs
@@ -16,4 +16,7 @@ public sealed class JobStatusCounts
 
     /// <summary>Number of jobs with status Failed.</summary>
     public int Failed { get; init; }
+
+    /// <summary>Number of jobs with status Cancelled.</summary>
+    public int Cancelled { get; init; }
 }

--- a/src/Atomizer/Abstractions/QueueStats.cs
+++ b/src/Atomizer/Abstractions/QueueStats.cs
@@ -19,4 +19,7 @@ public sealed class QueueStats
 
     /// <summary>Number of jobs with status Failed.</summary>
     public int Failed { get; init; }
+
+    /// <summary>Number of jobs with status Cancelled.</summary>
+    public int Cancelled { get; init; }
 }

--- a/src/Atomizer/Configuration/AtomizerJobHandlerDescriptor.cs
+++ b/src/Atomizer/Configuration/AtomizerJobHandlerDescriptor.cs
@@ -1,0 +1,23 @@
+namespace Atomizer;
+
+/// <summary>
+/// Describes a registered Atomizer job handler and the payload type it handles.
+/// </summary>
+public sealed class AtomizerJobHandlerDescriptor
+{
+    internal AtomizerJobHandlerDescriptor(Type payloadType, Type handlerType)
+    {
+        PayloadType = payloadType;
+        HandlerType = handlerType;
+    }
+
+    /// <summary>
+    /// Gets the payload type accepted by the handler.
+    /// </summary>
+    public Type PayloadType { get; }
+
+    /// <summary>
+    /// Gets the concrete handler type registered for the payload.
+    /// </summary>
+    public Type HandlerType { get; }
+}

--- a/src/Atomizer/Configuration/AtomizerOptions.cs
+++ b/src/Atomizer/Configuration/AtomizerOptions.cs
@@ -18,6 +18,12 @@ public sealed class AtomizerOptions
 
     internal List<QueueOptions> Queues { get; } = new List<QueueOptions>();
     internal List<ServiceDescriptor> Handlers { get; } = new List<ServiceDescriptor>();
+    private readonly List<AtomizerJobHandlerDescriptor> _jobHandlers = new List<AtomizerJobHandlerDescriptor>();
+
+    /// <summary>
+    /// Gets the registered job handler descriptors discovered through <see cref="AddHandlersFrom(Assembly[])"/>.
+    /// </summary>
+    public IReadOnlyList<AtomizerJobHandlerDescriptor> JobHandlers => _jobHandlers;
 
     /// <summary>
     /// Adds a named queue with optional configuration.
@@ -76,6 +82,11 @@ public sealed class AtomizerOptions
                 foreach (var handlerInterface in handlerInterfaces)
                 {
                     Handlers.Add(new ServiceDescriptor(handlerInterface, impl, ServiceLifetime.Scoped));
+                    var payloadType = handlerInterface.GenericTypeArguments[0];
+                    if (!_jobHandlers.Any(j => j.PayloadType == payloadType && j.HandlerType == impl))
+                    {
+                        _jobHandlers.Add(new AtomizerJobHandlerDescriptor(payloadType, impl));
+                    }
                 }
             }
         }

--- a/src/Atomizer/Models/AtomizerJob.cs
+++ b/src/Atomizer/Models/AtomizerJob.cs
@@ -257,6 +257,23 @@ public class AtomizerJob : Model
         UpdatedAt = now;
         LeaseToken = null;
     }
+
+    /// <summary>
+    /// Cancels a pending job so it is no longer eligible for processing.
+    /// </summary>
+    /// <param name="cancelledAt">The UTC time the job was cancelled.</param>
+    public void Cancel(DateTimeOffset cancelledAt)
+    {
+        if (Status != AtomizerJobStatus.Pending)
+        {
+            throw new InvalidOperationException("Job must be in Pending status to cancel.");
+        }
+
+        Status = AtomizerJobStatus.Cancelled;
+        UpdatedAt = cancelledAt;
+        LeaseToken = null;
+        VisibleAt = null;
+    }
 }
 
 /// <summary>
@@ -283,4 +300,9 @@ public enum AtomizerJobStatus
     /// The job exhausted all retry attempts and will not be retried.
     /// </summary>
     Failed = 4,
+
+    /// <summary>
+    /// The job was cancelled before processing.
+    /// </summary>
+    Cancelled = 5,
 }

--- a/src/Atomizer/Models/AtomizerSchedule.cs
+++ b/src/Atomizer/Models/AtomizerSchedule.cs
@@ -202,6 +202,16 @@ public class AtomizerSchedule : Model
         Enabled = false;
         UpdatedAt = now;
     }
+
+    /// <summary>
+    /// Enables this schedule so it can be polled again.
+    /// </summary>
+    /// <param name="now">The current UTC time used to set <see cref="AtomizerSchedule.UpdatedAt"/>.</param>
+    public void Enable(DateTimeOffset now)
+    {
+        Enabled = true;
+        UpdatedAt = now;
+    }
 }
 
 /// <summary>

--- a/src/Atomizer/Storage/InMemoryJobStorageOptions.cs
+++ b/src/Atomizer/Storage/InMemoryJobStorageOptions.cs
@@ -6,7 +6,7 @@ namespace Atomizer.Storage;
 public class InMemoryJobStorageOptions
 {
     /// <summary>
-    /// Gets or sets the maximum number of completed or failed jobs to retain in memory.
+    /// Gets or sets the maximum number of terminal jobs to retain in memory.
     /// <remarks>Default is 1000. Older terminal jobs are evicted when this limit is exceeded.</remarks>
     /// </summary>
     public int AmountOfJobsToRetainInMemory { get; set; } = 1000;

--- a/src/Atomizer/Storage/InMemoryStorage.cs
+++ b/src/Atomizer/Storage/InMemoryStorage.cs
@@ -360,7 +360,19 @@ public sealed class InMemoryStorage : IAtomizerStorage
         try
         {
             var now = _clock.UtcNow;
-            schedule.CreatedAt = schedule.CreatedAt == default ? now : schedule.CreatedAt;
+            if (_schedules.TryGetValue(schedule.JobKey, out var existing))
+            {
+                schedule.Id = existing.Id;
+                schedule.CreatedAt = existing.CreatedAt;
+                schedule.Enabled = existing.Enabled;
+                schedule.NextRunAt = existing.NextRunAt;
+                schedule.LastEnqueueAt = existing.LastEnqueueAt;
+            }
+            else
+            {
+                schedule.CreatedAt = schedule.CreatedAt == default ? now : schedule.CreatedAt;
+            }
+
             schedule.UpdatedAt = now;
             _schedules[schedule.JobKey] = schedule;
             _logger.LogDebug("UpsertSchedule: upserted schedule for jobKey={JobKey}", schedule.JobKey);
@@ -465,6 +477,7 @@ public sealed class InMemoryStorage : IAtomizerStorage
                 Processing = jobs.Count(j => j.Status == AtomizerJobStatus.Processing),
                 Completed = jobs.Count(j => j.Status == AtomizerJobStatus.Completed),
                 Failed = jobs.Count(j => j.Status == AtomizerJobStatus.Failed),
+                Cancelled = jobs.Count(j => j.Status == AtomizerJobStatus.Cancelled),
             }
         );
     }
@@ -541,6 +554,7 @@ public sealed class InMemoryStorage : IAtomizerStorage
                 Processing = g.Count(j => j.Status == AtomizerJobStatus.Processing),
                 Completed = g.Count(j => j.Status == AtomizerJobStatus.Completed),
                 Failed = g.Count(j => j.Status == AtomizerJobStatus.Failed),
+                Cancelled = g.Count(j => j.Status == AtomizerJobStatus.Cancelled),
             })
             .ToList();
 
@@ -614,7 +628,11 @@ public sealed class InMemoryStorage : IAtomizerStorage
 
         // Snapshot enumeration is safe on ConcurrentDictionary
         var terminal = _jobs
-            .Values.Where(j => j.Status == AtomizerJobStatus.Completed || j.Status == AtomizerJobStatus.Failed)
+            .Values.Where(j =>
+                j.Status == AtomizerJobStatus.Completed
+                || j.Status == AtomizerJobStatus.Failed
+                || j.Status == AtomizerJobStatus.Cancelled
+            )
             .OrderByDescending(j => j.UpdatedAt)
             .ToList();
 
@@ -647,7 +665,7 @@ public sealed class InMemoryStorage : IAtomizerStorage
         if (removed > 0)
         {
             _logger.LogDebug(
-                "Evicted {Count} completed/failed jobs; retaining {Retain} most-recent terminal jobs",
+                "Evicted {Count} terminal jobs; retaining {Retain} most-recent terminal jobs",
                 removed,
                 retain
             );

--- a/tests/Atomizer.Dashboard.Tests/Endpoints/JobsEndpointsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Endpoints/JobsEndpointsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text;
 using System.Text.Json;
 using Atomizer.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -244,6 +245,24 @@ public class JobsEndpointsTests : IClassFixture<DashboardTestHost>
         job!.QueueKey.Should().Be(new QueueKey("test-queue"));
         job.Payload.Should().Be("""{"message":"from-dashboard"}""");
         job.PayloadType.Should().Be(typeof(DashboardActionPayload));
+    }
+
+    [Fact]
+    public async Task TriggerJob_WhenRequestBodyMalformedJson_ShouldReturnBadRequest()
+    {
+        using var freshHost = new DashboardTestHost();
+        var client = freshHost.CreateClient();
+        using var content = new StringContent("{", Encoding.UTF8, "application/json");
+
+        var response = await client.PostAsync(
+            "/atomizer/api/jobs/trigger",
+            content,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().Contain("Malformed JSON request body.");
     }
 
     private static async Task InsertJobAsync(InMemoryStorage storage, QueueKey queue, AtomizerJobStatus status)

--- a/tests/Atomizer.Dashboard.Tests/Endpoints/JobsEndpointsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Endpoints/JobsEndpointsTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using Atomizer.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -147,6 +148,104 @@ public class JobsEndpointsTests : IClassFixture<DashboardTestHost>
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
+    [Fact]
+    public async Task RetryJob_WhenJobFailed_ShouldEnqueueReplacementJob()
+    {
+        using var freshHost = new DashboardTestHost();
+        var storage = freshHost.Services.GetRequiredService<InMemoryStorage>();
+        await InsertJobAsync(storage, QueueKey.Default, AtomizerJobStatus.Failed);
+        var source = (
+            await storage.GetJobsAsync(new JobQuery { Take = 10 }, TestContext.Current.CancellationToken)
+        ).Items.Single(j => j.Status == AtomizerJobStatus.Failed);
+        var client = freshHost.CreateClient();
+
+        var response = await client.PostAsync(
+            $"/atomizer/api/jobs/{source.Id}/retry",
+            content: null,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<JobActionResponseDto>(body, JsonOptions);
+        result.Should().NotBeNull();
+        result!.JobId.Should().NotBe(source.Id);
+
+        var replacement = await storage.GetJobByIdAsync(result.JobId, TestContext.Current.CancellationToken);
+        replacement.Should().NotBeNull();
+        replacement!.Status.Should().Be(AtomizerJobStatus.Pending);
+        replacement.Payload.Should().Be(source.Payload);
+        replacement.Attempts.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task CancelJob_WhenJobPending_ShouldMarkJobCancelled()
+    {
+        using var freshHost = new DashboardTestHost();
+        var atomizerClient = freshHost.Services.GetRequiredService<IAtomizerClient>();
+        var id = await atomizerClient.EnqueueAsync("cancel-me", cancellation: TestContext.Current.CancellationToken);
+        var client = freshHost.CreateClient();
+
+        var response = await client.PostAsync(
+            $"/atomizer/api/jobs/{id}/cancel",
+            content: null,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<JobActionResponseDto>(body, JsonOptions);
+        result.Should().NotBeNull();
+        result!.Status.Should().Be("Cancelled");
+
+        var detail = await client.GetAsync($"/atomizer/api/jobs/{id}", TestContext.Current.CancellationToken);
+        var detailBody = await detail.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var job = JsonSerializer.Deserialize<JobDetailResponseDto>(detailBody, JsonOptions);
+        job.Should().NotBeNull();
+        job!.Status.Should().Be("Cancelled");
+    }
+
+    [Fact]
+    public async Task TriggerJob_WhenRegisteredPayloadTypeAndValidJson_ShouldEnqueueJob()
+    {
+        using var freshHost = new DashboardTestHost();
+        var client = freshHost.CreateClient();
+
+        var optionsResponse = await client.GetAsync("/atomizer/api/job-types", TestContext.Current.CancellationToken);
+        optionsResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var optionsBody = await optionsResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var options = JsonSerializer.Deserialize<List<JobTypeOptionDto>>(optionsBody, JsonOptions);
+        var option = options
+            .Should()
+            .NotBeNull()
+            .And.ContainSingle(o => o.PayloadTypeName == nameof(DashboardActionPayload))
+            .Subject;
+
+        var response = await client.PostAsJsonAsync(
+            "/atomizer/api/jobs/trigger",
+            new
+            {
+                payloadTypeId = option.Id,
+                queueKey = "test-queue",
+                payload = """{"message":"from-dashboard"}""",
+            },
+            JsonOptions,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<JobActionResponseDto>(body, JsonOptions);
+        result.Should().NotBeNull();
+
+        var storage = freshHost.Services.GetRequiredService<InMemoryStorage>();
+        var job = await storage.GetJobByIdAsync(result!.JobId, TestContext.Current.CancellationToken);
+        job.Should().NotBeNull();
+        job!.QueueKey.Should().Be(new QueueKey("test-queue"));
+        job.Payload.Should().Be("""{"message":"from-dashboard"}""");
+        job.PayloadType.Should().Be(typeof(DashboardActionPayload));
+    }
+
     private static async Task InsertJobAsync(InMemoryStorage storage, QueueKey queue, AtomizerJobStatus status)
     {
         var now = DateTimeOffset.UtcNow;
@@ -190,6 +289,7 @@ internal sealed class JobStatusCountsDto
     public int Processing { get; init; }
     public int Completed { get; init; }
     public int Failed { get; init; }
+    public int Cancelled { get; init; }
 }
 
 internal sealed class JobItemDto
@@ -212,6 +312,20 @@ internal sealed class JobDetailResponseDto
     public DateTimeOffset CreatedAt { get; init; }
     public string Payload { get; init; } = string.Empty;
     public IReadOnlyList<JobErrorItemDto> Errors { get; init; } = new List<JobErrorItemDto>();
+}
+
+internal sealed class JobActionResponseDto
+{
+    public Guid JobId { get; init; }
+    public Guid? SourceJobId { get; init; }
+    public string Status { get; init; } = string.Empty;
+}
+
+internal sealed class JobTypeOptionDto
+{
+    public string Id { get; init; } = string.Empty;
+    public string PayloadTypeName { get; init; } = string.Empty;
+    public string PayloadTypeFullName { get; init; } = string.Empty;
 }
 
 internal sealed class JobErrorItemDto

--- a/tests/Atomizer.Dashboard.Tests/Endpoints/QueueStatsEndpointsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Endpoints/QueueStatsEndpointsTests.cs
@@ -91,4 +91,5 @@ internal sealed class QueueStatItemDto
     public int Processing { get; init; }
     public int Completed { get; init; }
     public int Failed { get; init; }
+    public int Cancelled { get; init; }
 }

--- a/tests/Atomizer.Dashboard.Tests/Endpoints/SchedulesEndpointsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Endpoints/SchedulesEndpointsTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
+using Atomizer.Storage;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Atomizer.Dashboard.Tests.Endpoints;
@@ -52,6 +54,96 @@ public class SchedulesEndpointsTests : IClassFixture<DashboardTestHost>
         result.Should().NotBeEmpty();
         result!.Should().Contain(s => s.JobKey == "test-recurring-schedule");
     }
+
+    [Fact]
+    public async Task SetScheduleEnabled_WhenScheduleExists_ShouldToggleScheduleAndSurviveRegistrationUpsert()
+    {
+        using var freshHost = new DashboardTestHost();
+        var atomizerClient = freshHost.Services.GetRequiredService<IAtomizerClient>();
+        var jobKey = new JobKey("toggle-schedule");
+        await atomizerClient.ScheduleRecurringAsync(
+            "recurring-payload",
+            jobKey,
+            Schedule.Every().Minute(),
+            configure: options => options.Enabled = true,
+            cancellation: TestContext.Current.CancellationToken
+        );
+        var storage = freshHost.Services.GetRequiredService<InMemoryStorage>();
+        var schedule = (await storage.GetSchedulesAsync(TestContext.Current.CancellationToken)).Single(s =>
+            s.JobKey == jobKey
+        );
+        var originalNextRunAt = schedule.NextRunAt;
+        var client = freshHost.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            $"/atomizer/api/schedules/{schedule.Id}/enabled",
+            new { enabled = false },
+            JsonOptions,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<ScheduleActionResponseDto>(body, JsonOptions);
+        result.Should().NotBeNull();
+        result!.Schedule.Enabled.Should().BeFalse();
+
+        await atomizerClient.ScheduleRecurringAsync(
+            "recurring-payload",
+            jobKey,
+            Schedule.Every().Minute(),
+            configure: options => options.Enabled = true,
+            cancellation: TestContext.Current.CancellationToken
+        );
+
+        var afterRestartRegistration = (await storage.GetSchedulesAsync(TestContext.Current.CancellationToken)).Single(
+            s => s.JobKey == jobKey
+        );
+        afterRestartRegistration.Enabled.Should().BeFalse();
+        afterRestartRegistration.NextRunAt.Should().Be(originalNextRunAt);
+    }
+
+    [Fact]
+    public async Task RunScheduleNow_WhenScheduleExists_ShouldEnqueueOneJobWithoutMovingNextRun()
+    {
+        using var freshHost = new DashboardTestHost();
+        var atomizerClient = freshHost.Services.GetRequiredService<IAtomizerClient>();
+        await atomizerClient.ScheduleRecurringAsync(
+            new DashboardActionPayload { Message = "scheduled-now" },
+            new JobKey("manual-run-schedule"),
+            Schedule.Every().Minute(),
+            configure: options => options.Queue = new QueueKey("test-queue"),
+            cancellation: TestContext.Current.CancellationToken
+        );
+        var storage = freshHost.Services.GetRequiredService<InMemoryStorage>();
+        var schedule = (await storage.GetSchedulesAsync(TestContext.Current.CancellationToken)).Single(s =>
+            s.JobKey == new JobKey("manual-run-schedule")
+        );
+        var originalNextRunAt = schedule.NextRunAt;
+        var client = freshHost.CreateClient();
+
+        var response = await client.PostAsync(
+            $"/atomizer/api/schedules/{schedule.Id}/run-now",
+            content: null,
+            TestContext.Current.CancellationToken
+        );
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        var result = JsonSerializer.Deserialize<JobActionResponseDto>(body, JsonOptions);
+        result.Should().NotBeNull();
+
+        var job = await storage.GetJobByIdAsync(result!.JobId, TestContext.Current.CancellationToken);
+        job.Should().NotBeNull();
+        job!.QueueKey.Should().Be(new QueueKey("test-queue"));
+        job.ScheduleJobKey.Should().Be(schedule.JobKey);
+        job.Payload.Should().Be(schedule.Payload);
+
+        var scheduleAfterRun = (await storage.GetSchedulesAsync(TestContext.Current.CancellationToken)).Single(s =>
+            s.Id == schedule.Id
+        );
+        scheduleAfterRun.NextRunAt.Should().Be(originalNextRunAt);
+    }
 }
 
 internal sealed class ScheduleItemDto
@@ -63,4 +155,9 @@ internal sealed class ScheduleItemDto
     public string Cron { get; init; } = string.Empty;
     public DateTimeOffset NextRunAt { get; init; }
     public bool Enabled { get; init; }
+}
+
+internal sealed class ScheduleActionResponseDto
+{
+    public ScheduleItemDto Schedule { get; init; } = new();
 }

--- a/tests/Atomizer.Dashboard.Tests/Services/DashboardCommandServiceTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Services/DashboardCommandServiceTests.cs
@@ -1,0 +1,37 @@
+using Atomizer.Abstractions;
+using Atomizer.Core;
+using Atomizer.Dashboard.Services;
+using NSubstitute;
+
+namespace Atomizer.Dashboard.Tests.Services;
+
+public class DashboardCommandServiceTests
+{
+    [Fact]
+    public async Task CancelJobAsync_WhenJobIsLeasedAfterRead_ShouldReturnConflict()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var job = AtomizerJob.Create(QueueKey.Default, typeof(string), "payload", now, now);
+        var storage = Substitute.For<IAtomizerStorage>();
+        var clock = Substitute.For<IAtomizerClock>();
+        var serializer = Substitute.For<IAtomizerJobSerializer>();
+        var options = new AtomizerOptions();
+
+        storage.GetJobByIdAsync(job.Id, Arg.Any<CancellationToken>()).Returns(job);
+        clock.UtcNow.Returns(_ =>
+        {
+            job.Status = AtomizerJobStatus.Processing;
+            return now.AddSeconds(1);
+        });
+
+        var service = new DashboardCommandService(storage, clock, serializer, options);
+
+        var result = await service.CancelJobAsync(job.Id, TestContext.Current.CancellationToken);
+
+        result.StatusCode.Should().Be(409);
+        result.Message.Should().Be("Job must be in Pending status to cancel.");
+        await storage
+            .DidNotReceive()
+            .UpdateJobsAsync(Arg.Any<IEnumerable<AtomizerJob>>(), Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Atomizer.Dashboard.Tests/TestHost.cs
+++ b/tests/Atomizer.Dashboard.Tests/TestHost.cs
@@ -28,6 +28,7 @@ public abstract class DashboardHostBase : WebApplicationFactory<Program>
                     {
                         options.UseInMemoryStorage();
                         options.AddQueue("test-queue", _ => { });
+                        options.AddHandlersFrom(typeof(DashboardHostBase).Assembly);
                     });
                     services.AddSingleton(sp =>
                         (Atomizer.Storage.InMemoryStorage)sp.GetRequiredService<IAtomizerStorage>()
@@ -105,4 +106,14 @@ public sealed class UnauthorizedAuthFilter : IAtomizerDashboardAuthorizationFilt
 internal sealed class AlwaysAllowAuthFilter : IAtomizerDashboardAuthorizationFilter
 {
     public DashboardAuthorizationResult Authorize(HttpContext context) => DashboardAuthorizationResult.Authorized;
+}
+
+internal sealed class DashboardActionPayload
+{
+    public string Message { get; init; } = string.Empty;
+}
+
+internal sealed class DashboardActionJob : IAtomizerJob<DashboardActionPayload>
+{
+    public Task HandleAsync(DashboardActionPayload payload, JobContext context) => Task.CompletedTask;
 }

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
@@ -747,8 +747,8 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
         scheduleId.Should().Be(schedule.Id);
         updatedScheduleEntity.Should().NotBeNull();
         updatedScheduleEntity.Enabled.Should().BeFalse();
-        updatedScheduleEntity.NextRunAt.Should().Be(now.AddHours(-1));
-        updatedScheduleEntity.LastEnqueueAt.Should().Be(now.AddHours(-2));
+        updatedScheduleEntity.NextRunAt.Should().BeCloseTo(now.AddHours(-1), TimeSpan.FromTicks(10));
+        updatedScheduleEntity.LastEnqueueAt.Should().BeCloseTo(now.AddHours(-2), TimeSpan.FromTicks(10));
         updatedScheduleEntity.Payload.Should().Be("""{ "message": "Updated Schedule" }""");
     }
 

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreStorageTests.cs
@@ -700,6 +700,59 @@ public abstract class EntityFrameworkCoreStorageTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpsertScheduleAsync_WhenScheduleExists_ShouldPreserveOperationalState()
+    {
+        // Arrange
+        var now = _clock.UtcNow;
+        var schedule = AtomizerSchedule.Create(
+            new JobKey("WriteLineMessage-preserve-state"),
+            QueueKey.Default,
+            typeof(WriteLineMessage),
+            """{ "message": "Initial Schedule" }""",
+            Schedule.Every().Minute(),
+            TimeZoneInfo.Utc,
+            now,
+            enabled: true
+        );
+
+        await using var dbContext = _dbContextFactory();
+        var storage = _storageFactory(dbContext);
+
+        await storage.UpsertScheduleAsync(schedule, CancellationToken.None);
+        schedule.Disable(now.AddMinutes(1));
+        schedule.NextRunAt = now.AddHours(-1);
+        schedule.LastEnqueueAt = now.AddHours(-2);
+        await storage.UpdateSchedulesAsync([schedule], CancellationToken.None);
+
+        dbContext.ChangeTracker.Clear();
+
+        var registration = AtomizerSchedule.Create(
+            schedule.JobKey,
+            QueueKey.Default,
+            typeof(WriteLineMessage),
+            """{ "message": "Updated Schedule" }""",
+            Schedule.Every().Minute(),
+            TimeZoneInfo.Utc,
+            now.AddHours(1),
+            enabled: true
+        );
+
+        // Act
+        var scheduleId = await storage.UpsertScheduleAsync(registration, CancellationToken.None);
+        var updatedScheduleEntity = await dbContext
+            .Set<AtomizerScheduleEntity>()
+            .FirstOrDefaultAsync(s => s.Id == scheduleId, TestContext.Current.CancellationToken);
+
+        // Assert
+        scheduleId.Should().Be(schedule.Id);
+        updatedScheduleEntity.Should().NotBeNull();
+        updatedScheduleEntity.Enabled.Should().BeFalse();
+        updatedScheduleEntity.NextRunAt.Should().Be(now.AddHours(-1));
+        updatedScheduleEntity.LastEnqueueAt.Should().Be(now.AddHours(-2));
+        updatedScheduleEntity.Payload.Should().Be("""{ "message": "Updated Schedule" }""");
+    }
+
+    [Fact]
     public async Task HeartbeatUpsert_WhenRepeated_ShouldPersistSingleActiveServerRecord()
     {
         // Arrange

--- a/tests/Atomizer.Tests/Models/AtomizerJobPartitionTests.cs
+++ b/tests/Atomizer.Tests/Models/AtomizerJobPartitionTests.cs
@@ -71,4 +71,37 @@ public class AtomizerJobPartitionTests
         // Assert
         job.IsPartitionBlocked.Should().BeTrue();
     }
+
+    [Fact]
+    public void Cancel_WhenJobIsPending_ShouldMarkJobCancelled()
+    {
+        // Arrange
+        var job = CreateJob();
+        var cancelledAt = DateTimeOffset.UtcNow;
+
+        // Act
+        job.Cancel(cancelledAt);
+
+        // Assert
+        job.Status.Should().Be(AtomizerJobStatus.Cancelled);
+        job.UpdatedAt.Should().Be(cancelledAt);
+    }
+
+    [Fact]
+    public void Cancel_WhenJobIsProcessing_ShouldThrow()
+    {
+        // Arrange
+        var job = CreateJob();
+        job.Lease(
+            new LeaseToken($"worker:*:default:*:{Guid.NewGuid()}"),
+            DateTimeOffset.UtcNow,
+            TimeSpan.FromMinutes(10)
+        );
+
+        // Act
+        Action act = () => job.Cancel(DateTimeOffset.UtcNow);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Pending status*");
+    }
 }

--- a/tests/Atomizer.Tests/Storage/InMemoryStorageTests.cs
+++ b/tests/Atomizer.Tests/Storage/InMemoryStorageTests.cs
@@ -223,6 +223,53 @@ namespace Atomizer.Tests.Storage
             schedules[schedule.JobKey].Should().Be(schedule);
         }
 
+        [Fact]
+        public async Task UpsertScheduleAsync_WhenScheduleExists_ShouldPreserveOperationalState()
+        {
+            // Arrange
+            var schedule = AtomizerSchedule.Create(
+                new JobKey("job1"),
+                QueueKey.Default,
+                typeof(string),
+                "payload",
+                Schedule.Default,
+                TimeZoneInfo.Utc,
+                _now,
+                enabled: true
+            );
+            await _sut.UpsertScheduleAsync(schedule, CancellationToken.None);
+            schedule.Disable(_now.AddMinutes(1));
+            schedule.NextRunAt = _now.AddHours(-1);
+            schedule.LastEnqueueAt = _now.AddHours(-2);
+            await _sut.UpdateSchedulesAsync([schedule], CancellationToken.None);
+
+            var registration = AtomizerSchedule.Create(
+                schedule.JobKey,
+                QueueKey.Default,
+                typeof(string),
+                "updated payload",
+                Schedule.Every().Minute(),
+                TimeZoneInfo.Utc,
+                _now.AddHours(1),
+                enabled: true
+            );
+
+            // Act
+            var id = await _sut.UpsertScheduleAsync(registration, CancellationToken.None);
+
+            // Assert
+            id.Should().Be(schedule.Id);
+            var schedules = NonPublicSpy.GetFieldValue<InMemoryStorage, Dictionary<JobKey, AtomizerSchedule>>(
+                "_schedules",
+                _sut
+            );
+            var stored = schedules[schedule.JobKey];
+            stored.Enabled.Should().BeFalse();
+            stored.NextRunAt.Should().Be(_now.AddHours(-1));
+            stored.LastEnqueueAt.Should().Be(_now.AddHours(-2));
+            stored.Payload.Should().Be("updated payload");
+        }
+
         /// <summary>
         /// Verifies that LeaseDueSchedulesAsync leases due schedules and updates their state.
         /// </summary>


### PR DESCRIPTION
## Summary
- Add dashboard actions for retrying failed jobs, cancelling pending jobs, and triggering registered payload types with custom JSON.
- Add schedule enable/disable and run-now actions while preserving operator-controlled schedule state across registration upserts.
- Surface cancelled job state and counts across dashboard API and UI.

## Changes
- Added dashboard command service, REST routes, action DTOs, and React controls for job and schedule actions.
- Added `Cancelled` job state, cancel/enable domain methods, handler payload metadata, and cancelled stats support.
- Updated in-memory and EF schedule upsert behavior so conflicts do not overwrite `Enabled`, `NextRunAt`, or `LastEnqueueAt`.
- Covered the new action flows and schedule-state preservation with dashboard, domain, in-memory, and EF storage checks.
- Checked with `npm run typecheck`, `npm run build`, `dotnet csharpier check .`, `dotnet build Atomizer.sln --no-restore`, and focused `dotnet test` runs for dashboard/core/EF behavior.