### PR TITLE
feat: add job retention cleanup

### DIFF
--- a/src/Atomizer.EntityFrameworkCore/Providers/ISqlDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/ISqlDialect.cs
@@ -4,6 +4,7 @@ internal interface ISqlDialect
 {
     FormattableString GetDueJobs(QueueKey queueKey, DateTimeOffset now, int batchSize);
     FormattableString ReleaseLeasedJobs(LeaseToken leaseToken, DateTimeOffset now);
+    FormattableString DeleteExpiredJobs(DateTimeOffset terminalBefore);
     FormattableString GetDueSchedules(DateTimeOffset now);
     FormattableString UpsertSchedule(AtomizerSchedule schedule, DateTimeOffset now);
 

--- a/src/Atomizer.EntityFrameworkCore/Providers/Sql/BaseSqlDialect.cs
+++ b/src/Atomizer.EntityFrameworkCore/Providers/Sql/BaseSqlDialect.cs
@@ -16,6 +16,8 @@ internal abstract class BaseSqlDialect : ISqlDialect
     protected readonly string _jStatus;
     protected readonly string _jAttempts;
     protected readonly string _jRetryIntervals;
+    protected readonly string _jCompletedAt;
+    protected readonly string _jFailedAt;
     protected readonly string _jCreatedAt;
     protected readonly string _jUpdatedAt;
     protected readonly string _jLeaseToken;
@@ -45,6 +47,9 @@ internal abstract class BaseSqlDialect : ISqlDialect
 
     protected readonly int _statusPending = (int)AtomizerEntityJobStatus.Pending;
     protected readonly int _statusProcessing = (int)AtomizerEntityJobStatus.Processing;
+    protected readonly int _statusCompleted = (int)AtomizerEntityJobStatus.Completed;
+    protected readonly int _statusFailed = (int)AtomizerEntityJobStatus.Failed;
+    protected readonly int _statusCancelled = (int)AtomizerEntityJobStatus.Cancelled;
 
     protected BaseSqlDialect(EntityMap jobs, EntityMap schedules)
     {
@@ -59,6 +64,8 @@ internal abstract class BaseSqlDialect : ISqlDialect
         _jStatus = jc[nameof(AtomizerJobEntity.Status)];
         _jAttempts = jc[nameof(AtomizerJobEntity.Attempts)];
         _jRetryIntervals = jc[nameof(AtomizerJobEntity.RetryIntervals)];
+        _jCompletedAt = jc[nameof(AtomizerJobEntity.CompletedAt)];
+        _jFailedAt = jc[nameof(AtomizerJobEntity.FailedAt)];
         _jCreatedAt = jc[nameof(AtomizerJobEntity.CreatedAt)];
         _jUpdatedAt = jc[nameof(AtomizerJobEntity.UpdatedAt)];
         _jLeaseToken = jc[nameof(AtomizerJobEntity.LeaseToken)];
@@ -93,15 +100,35 @@ internal abstract class BaseSqlDialect : ISqlDialect
     public FormattableString ReleaseLeasedJobs(LeaseToken leaseToken, DateTimeOffset now)
     {
         var format = $$"""
-            UPDATE {{_jTable}}
-            SET {{_jStatus}} = {{_statusPending}},
-                {{_jLeaseToken}} = NULL,
-                {{_jVisibleAt}} = NULL,
-                {{_jUpdatedAt}} = {0}
-            WHERE {{_jLeaseToken}} = {1}
-              AND {{_jStatus}} = {{_statusProcessing}};
+                UPDATE {{_jTable}}
+                SET {{_jStatus}} = {{_statusPending}},
+                    {{_jLeaseToken}} = NULL,
+                    {{_jVisibleAt}} = NULL,
+                    {{_jUpdatedAt}} = {0}
+                WHERE {{_jLeaseToken}} = {1}
+                  AND {{_jStatus}} = {{_statusProcessing}};
             """;
         return FormattableStringFactory.Create(format, now, leaseToken.Token);
+    }
+
+    public FormattableString DeleteExpiredJobs(DateTimeOffset terminalBefore)
+    {
+        var format = $$"""
+            DELETE FROM {{_jTable}}
+            WHERE (
+                {{_jStatus}} = {{_statusCompleted}}
+                AND COALESCE({{_jCompletedAt}}, {{_jUpdatedAt}}) < {0}
+            )
+            OR (
+                {{_jStatus}} = {{_statusFailed}}
+                AND COALESCE({{_jFailedAt}}, {{_jUpdatedAt}}) < {0}
+            )
+            OR (
+                {{_jStatus}} = {{_statusCancelled}}
+                AND {{_jUpdatedAt}} < {0}
+            );
+            """;
+        return FormattableStringFactory.Create(format, terminalBefore);
     }
 
     public abstract FormattableString GetDueJobs(QueueKey queueKey, DateTimeOffset now, int batchSize);

--- a/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
+++ b/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
@@ -403,34 +403,13 @@ internal sealed class EntityFrameworkCoreStorage<TDbContext> : IAtomizerStorage
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        var expiredJobIds = await JobEntities
-            .AsNoTracking()
-            .Where(job =>
-                (job.Status == AtomizerEntityJobStatus.Completed && (job.CompletedAt ?? job.UpdatedAt) < terminalBefore)
-                || (job.Status == AtomizerEntityJobStatus.Failed && (job.FailedAt ?? job.UpdatedAt) < terminalBefore)
-                || (job.Status == AtomizerEntityJobStatus.Cancelled && job.UpdatedAt < terminalBefore)
-            )
-            .Select(job => job.Id)
-            .ToListAsync(cancellationToken);
-
-        if (expiredJobIds.Count == 0)
+        if (_providerCache.Dialect is not null)
         {
-            return 0;
+            var sql = _providerCache.Dialect.DeleteExpiredJobs(terminalBefore);
+            return await _dbContext.Database.ExecuteSqlInterpolatedAsync(sql, cancellationToken);
         }
 
-        _dbContext.ChangeTracker.Clear();
-        JobEntities.RemoveRange(expiredJobIds.Select(id => new AtomizerJobEntity { Id = id }));
-
-        try
-        {
-            await _dbContext.SaveChangesAsync(cancellationToken);
-            return expiredJobIds.Count;
-        }
-        catch (DbUpdateException ex)
-        {
-            _logger.LogError(ex, "Failed to delete expired jobs");
-            throw;
-        }
+        throw UnsupportedProviderException(_providerCache.ProviderName);
     }
 
     public async Task<IReadOnlyList<AtomizerSchedule>> GetSchedulesAsync(CancellationToken cancellationToken)

--- a/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
+++ b/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
@@ -399,6 +399,40 @@ internal sealed class EntityFrameworkCoreStorage<TDbContext> : IAtomizerStorage
         return entity?.ToAtomizerJob();
     }
 
+    public async Task<int> DeleteExpiredJobsAsync(DateTimeOffset terminalBefore, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var expiredJobIds = await JobEntities
+            .AsNoTracking()
+            .Where(job =>
+                (job.Status == AtomizerEntityJobStatus.Completed && (job.CompletedAt ?? job.UpdatedAt) < terminalBefore)
+                || (job.Status == AtomizerEntityJobStatus.Failed && (job.FailedAt ?? job.UpdatedAt) < terminalBefore)
+                || (job.Status == AtomizerEntityJobStatus.Cancelled && job.UpdatedAt < terminalBefore)
+            )
+            .Select(job => job.Id)
+            .ToListAsync(cancellationToken);
+
+        if (expiredJobIds.Count == 0)
+        {
+            return 0;
+        }
+
+        _dbContext.ChangeTracker.Clear();
+        JobEntities.RemoveRange(expiredJobIds.Select(id => new AtomizerJobEntity { Id = id }));
+
+        try
+        {
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return expiredJobIds.Count;
+        }
+        catch (DbUpdateException ex)
+        {
+            _logger.LogError(ex, "Failed to delete expired jobs");
+            throw;
+        }
+    }
+
     public async Task<IReadOnlyList<AtomizerSchedule>> GetSchedulesAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/src/Atomizer/Abstractions/IAtomizerStorage.cs
+++ b/src/Atomizer/Abstractions/IAtomizerStorage.cs
@@ -111,6 +111,14 @@ public interface IAtomizerStorage
     Task<AtomizerJob?> GetJobByIdAsync(Guid id, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Deletes terminal jobs whose terminal timestamp is older than the supplied cutoff.
+    /// </summary>
+    /// <param name="terminalBefore">The exclusive UTC cutoff for completed, failed, or cancelled jobs.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <returns>The number of jobs deleted.</returns>
+    Task<int> DeleteExpiredJobsAsync(DateTimeOffset terminalBefore, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Returns all registered recurring schedules.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>

--- a/src/Atomizer/Configuration/AtomizerProcessingOptions.cs
+++ b/src/Atomizer/Configuration/AtomizerProcessingOptions.cs
@@ -36,6 +36,18 @@ public class AtomizerProcessingOptions
     public TimeSpan? StaleSweepInterval { get; set; }
 
     /// <summary>
+    /// Gets or sets how long terminal jobs are retained before cleanup removes them.
+    /// <remarks>Default is <see langword="null"/>, which keeps jobs forever.</remarks>
+    /// </summary>
+    public TimeSpan? JobRetention { get; set; }
+
+    /// <summary>
+    /// Gets or sets how frequently job retention cleanup scans run when <see cref="JobRetention"/> is configured.
+    /// <remarks>Default is 1 hour.</remarks>
+    /// </summary>
+    public TimeSpan JobRetentionSweepInterval { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
     /// Gets the configured stale sweep interval, defaulting to <see cref="HeartbeatInterval"/>.
     /// </summary>
     public TimeSpan EffectiveStaleSweepInterval => StaleSweepInterval ?? HeartbeatInterval;
@@ -66,6 +78,19 @@ public class AtomizerProcessingOptions
         if (StaleSweepInterval.HasValue && StaleSweepInterval.Value <= TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(nameof(StaleSweepInterval), "Stale sweep interval must be positive.");
+        }
+
+        if (JobRetention.HasValue && JobRetention.Value <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(JobRetention), "Job retention must be positive.");
+        }
+
+        if (JobRetention.HasValue && JobRetentionSweepInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(JobRetentionSweepInterval),
+                "Job retention sweep interval must be positive."
+            );
         }
 
         if (StaleServerTimeout < TimeSpan.FromTicks(HeartbeatInterval.Ticks * 6))

--- a/src/Atomizer/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Atomizer/Configuration/ServiceCollectionExtensions.cs
@@ -79,6 +79,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<AtomizerRuntimeIdentity>();
         services.AddHostedService<AtomizerHeartbeatRecoveryService>();
         services.AddHostedService<AtomizerQueueService>();
+        if (options.JobRetention is not null)
+        {
+            services.AddHostedService<AtomizerJobRetentionService>();
+        }
+
         services.AddSingleton<IQueueCoordinator, QueueCoordinator>();
         services.AddSingleton<IQueuePumpFactory, QueuePumpFactory>();
         services.AddSingleton<IQueuePoller, QueuePoller>();

--- a/src/Atomizer/Processing/AtomizerJobRetentionService.cs
+++ b/src/Atomizer/Processing/AtomizerJobRetentionService.cs
@@ -1,0 +1,76 @@
+using Atomizer.Abstractions;
+using Atomizer.Core;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Atomizer.Processing;
+
+internal sealed class AtomizerJobRetentionService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly AtomizerProcessingOptions _options;
+    private readonly IAtomizerClock _clock;
+    private readonly ILogger<AtomizerJobRetentionService> _logger;
+
+    public AtomizerJobRetentionService(
+        IServiceScopeFactory scopeFactory,
+        AtomizerProcessingOptions options,
+        IAtomizerClock clock,
+        ILogger<AtomizerJobRetentionService> logger
+    )
+    {
+        _scopeFactory = scopeFactory;
+        _options = options;
+        _clock = clock;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _options.Validate();
+
+        if (_options.JobRetention is null)
+        {
+            return;
+        }
+
+        if (_options.StartupDelay != null)
+        {
+            await Task.Delay(_options.StartupDelay.Value, stoppingToken);
+        }
+
+        _logger.LogInformation("Atomizer job retention service starting");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await DeleteExpiredJobsAsync(_options.JobRetention.Value, stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during Atomizer job retention tick");
+            }
+
+            await Task.Delay(_options.JobRetentionSweepInterval, stoppingToken);
+        }
+    }
+
+    private async Task DeleteExpiredJobsAsync(TimeSpan retention, CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IAtomizerStorage>();
+        var cutoff = _clock.UtcNow - retention;
+
+        var deleted = await storage.DeleteExpiredJobsAsync(cutoff, cancellationToken);
+        if (deleted > 0)
+        {
+            _logger.LogInformation("Deleted {Count} expired Atomizer job(s) older than {Cutoff:o}", deleted, cutoff);
+        }
+    }
+}

--- a/src/Atomizer/Storage/InMemoryStorage.cs
+++ b/src/Atomizer/Storage/InMemoryStorage.cs
@@ -519,6 +519,28 @@ public sealed class InMemoryStorage : IAtomizerStorage
     }
 
     /// <inheritdoc/>
+    public Task<int> DeleteExpiredJobsAsync(DateTimeOffset terminalBefore, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var expired = _jobs
+            .Values.Where(job =>
+            {
+                var terminalAt = GetTerminalTimestamp(job);
+                return terminalAt.HasValue && terminalAt.Value < terminalBefore;
+            })
+            .ToList();
+
+        var removed = RemoveJobs(expired);
+        if (removed > 0)
+        {
+            _logger.LogDebug("Deleted {Count} terminal jobs older than {TerminalBefore:o}", removed, terminalBefore);
+        }
+
+        return Task.FromResult(removed);
+    }
+
+    /// <inheritdoc/>
     public Task<IReadOnlyList<AtomizerSchedule>> GetSchedulesAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -640,13 +662,37 @@ public sealed class InMemoryStorage : IAtomizerStorage
         if (toRemove.Count == 0)
             return;
 
+        var removed = RemoveJobs(toRemove);
+
+        if (removed > 0)
+        {
+            _logger.LogDebug(
+                "Evicted {Count} terminal jobs; retaining {Retain} most-recent terminal jobs",
+                removed,
+                retain
+            );
+        }
+    }
+
+    private static DateTimeOffset? GetTerminalTimestamp(AtomizerJob job)
+    {
+        return job.Status switch
+        {
+            AtomizerJobStatus.Completed => job.CompletedAt ?? job.UpdatedAt,
+            AtomizerJobStatus.Failed => job.FailedAt ?? job.UpdatedAt,
+            AtomizerJobStatus.Cancelled => job.UpdatedAt,
+            _ => null,
+        };
+    }
+
+    private int RemoveJobs(IEnumerable<AtomizerJob> jobs)
+    {
         var removed = 0;
 
-        foreach (var job in toRemove)
+        foreach (var job in jobs)
         {
             UnindexFromQueue(job);
 
-            // Remove from leases set (if any)
             var leaseToken = job.LeaseToken?.Token;
             if (!string.IsNullOrEmpty(leaseToken) && _leasesByToken.TryGetValue(leaseToken!, out var set))
             {
@@ -657,19 +703,13 @@ public sealed class InMemoryStorage : IAtomizerStorage
                 }
             }
 
-            // Finally remove from jobs
-            _jobs.TryRemove(job.Id, out _);
-            removed++;
+            if (_jobs.TryRemove(job.Id, out _))
+            {
+                removed++;
+            }
         }
 
-        if (removed > 0)
-        {
-            _logger.LogDebug(
-                "Evicted {Count} terminal jobs; retaining {Retain} most-recent terminal jobs",
-                removed,
-                retain
-            );
-        }
+        return removed;
     }
 
     private int ReleaseMatchingJobs(Func<AtomizerJob, bool> predicate, DateTimeOffset now)

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/MySqlDialectTests.cs
@@ -59,6 +59,20 @@ public sealed class MySqlDialectTests
     }
 
     [Fact]
+    public void DeleteExpiredJobs_WhenCalled_ShouldContainSingleDeleteStatement()
+    {
+        var (jobs, schedules) = BuildMaps();
+        var dialect = new MySqlDialect(jobs, schedules);
+
+        var sql = dialect.DeleteExpiredJobs(DateTimeOffset.UtcNow);
+
+        sql.Format.Should().Contain("DELETE FROM");
+        sql.Format.Should().Contain("COALESCE");
+        sql.Format.Should().NotContain("SELECT");
+        sql.ArgumentCount.Should().Be(1);
+    }
+
+    [Fact]
     public void UpsertSchedule_WhenCalled_ShouldContainOnDuplicateKeyUpdate()
     {
         var (jobs, schedules) = BuildMaps();

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/PostgreSqlDialectTests.cs
@@ -60,6 +60,20 @@ public sealed class PostgreSqlDialectTests
     }
 
     [Fact]
+    public void DeleteExpiredJobs_WhenCalled_ShouldContainSingleDeleteStatement()
+    {
+        var (jobs, schedules) = BuildMaps();
+        var dialect = new PostgreSqlDialect(jobs, schedules);
+
+        var sql = dialect.DeleteExpiredJobs(DateTimeOffset.UtcNow);
+
+        sql.Format.Should().Contain("DELETE FROM");
+        sql.Format.Should().Contain("COALESCE");
+        sql.Format.Should().NotContain("SELECT");
+        sql.ArgumentCount.Should().Be(1);
+    }
+
+    [Fact]
     public void UpsertSchedule_WhenCalled_ShouldContainOnConflict()
     {
         var (jobs, schedules) = BuildMaps();

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Providers/SqlServerDialectTests.cs
@@ -60,6 +60,20 @@ public sealed class SqlServerDialectTests
     }
 
     [Fact]
+    public void DeleteExpiredJobs_WhenCalled_ShouldContainSingleDeleteStatement()
+    {
+        var (jobs, schedules) = BuildMaps();
+        var dialect = new SqlServerDialect(jobs, schedules);
+
+        var sql = dialect.DeleteExpiredJobs(DateTimeOffset.UtcNow);
+
+        sql.Format.Should().Contain("DELETE FROM");
+        sql.Format.Should().Contain("COALESCE");
+        sql.Format.Should().NotContain("SELECT");
+        sql.ArgumentCount.Should().Be(1);
+    }
+
+    [Fact]
     public void UpsertSchedule_WhenCalled_ShouldContainMergeWithHoldlock()
     {
         var (jobs, schedules) = BuildMaps();

--- a/tests/Atomizer.Tests.Utilities/StorageContract/AtomizerStorageContractTests.cs
+++ b/tests/Atomizer.Tests.Utilities/StorageContract/AtomizerStorageContractTests.cs
@@ -507,6 +507,7 @@ public abstract class AtomizerStorageContractTests : IAsyncLifetime
         var expiredFailed = CreateJob();
         var expiredCancelled = CreateJob();
         var oldPending = CreateJob();
+        var expiredAt = cutoff.AddSeconds(-1);
 
         await _sut.InsertAsync(expiredCompleted, CancellationToken.None);
         await _sut.InsertAsync(retainedCompleted, CancellationToken.None);
@@ -515,12 +516,12 @@ public abstract class AtomizerStorageContractTests : IAsyncLifetime
         await _sut.InsertAsync(oldPending, CancellationToken.None);
 
         expiredCompleted.Lease(FakeDataFactory.LeaseToken(), _now, TimeSpan.FromMinutes(10));
-        expiredCompleted.MarkAsCompleted(cutoff.AddTicks(-1));
+        expiredCompleted.MarkAsCompleted(expiredAt);
         retainedCompleted.Lease(FakeDataFactory.LeaseToken(), _now, TimeSpan.FromMinutes(10));
         retainedCompleted.MarkAsCompleted(cutoff);
         expiredFailed.Lease(FakeDataFactory.LeaseToken(), _now, TimeSpan.FromMinutes(10));
-        expiredFailed.MarkAsFailed(cutoff.AddTicks(-1));
-        expiredCancelled.Cancel(cutoff.AddTicks(-1));
+        expiredFailed.MarkAsFailed(expiredAt);
+        expiredCancelled.Cancel(expiredAt);
         oldPending.CreatedAt = cutoff.AddDays(-30);
         oldPending.UpdatedAt = cutoff.AddDays(-30);
 

--- a/tests/Atomizer.Tests.Utilities/StorageContract/AtomizerStorageContractTests.cs
+++ b/tests/Atomizer.Tests.Utilities/StorageContract/AtomizerStorageContractTests.cs
@@ -492,6 +492,54 @@ public abstract class AtomizerStorageContractTests : IAsyncLifetime
     }
 
     // ------------------------------------------------------------------
+    // Job retention cleanup
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Retention cleanup deletes only terminal jobs older than the supplied cutoff.
+    /// </summary>
+    [Fact]
+    public async Task DeleteExpiredJobsAsync_WhenJobsAreOutsideRetention_ShouldDeleteOnlyExpiredTerminalJobs()
+    {
+        var cutoff = _now.AddDays(-7);
+        var expiredCompleted = CreateJob();
+        var retainedCompleted = CreateJob();
+        var expiredFailed = CreateJob();
+        var expiredCancelled = CreateJob();
+        var oldPending = CreateJob();
+
+        await _sut.InsertAsync(expiredCompleted, CancellationToken.None);
+        await _sut.InsertAsync(retainedCompleted, CancellationToken.None);
+        await _sut.InsertAsync(expiredFailed, CancellationToken.None);
+        await _sut.InsertAsync(expiredCancelled, CancellationToken.None);
+        await _sut.InsertAsync(oldPending, CancellationToken.None);
+
+        expiredCompleted.Lease(FakeDataFactory.LeaseToken(), _now, TimeSpan.FromMinutes(10));
+        expiredCompleted.MarkAsCompleted(cutoff.AddTicks(-1));
+        retainedCompleted.Lease(FakeDataFactory.LeaseToken(), _now, TimeSpan.FromMinutes(10));
+        retainedCompleted.MarkAsCompleted(cutoff);
+        expiredFailed.Lease(FakeDataFactory.LeaseToken(), _now, TimeSpan.FromMinutes(10));
+        expiredFailed.MarkAsFailed(cutoff.AddTicks(-1));
+        expiredCancelled.Cancel(cutoff.AddTicks(-1));
+        oldPending.CreatedAt = cutoff.AddDays(-30);
+        oldPending.UpdatedAt = cutoff.AddDays(-30);
+
+        await _sut.UpdateJobsAsync(
+            [expiredCompleted, retainedCompleted, expiredFailed, expiredCancelled, oldPending],
+            CancellationToken.None
+        );
+
+        var deleted = await _sut.DeleteExpiredJobsAsync(cutoff, CancellationToken.None);
+
+        deleted.Should().Be(3);
+        (await _sut.GetJobByIdAsync(expiredCompleted.Id, CancellationToken.None)).Should().BeNull();
+        (await _sut.GetJobByIdAsync(expiredFailed.Id, CancellationToken.None)).Should().BeNull();
+        (await _sut.GetJobByIdAsync(expiredCancelled.Id, CancellationToken.None)).Should().BeNull();
+        (await _sut.GetJobByIdAsync(retainedCompleted.Id, CancellationToken.None)).Should().NotBeNull();
+        (await _sut.GetJobByIdAsync(oldPending.Id, CancellationToken.None)).Should().NotBeNull();
+    }
+
+    // ------------------------------------------------------------------
     // Helper
     // ------------------------------------------------------------------
 

--- a/tests/Atomizer.Tests/Configuration/ServiceCollectionExtensionsTests.cs
+++ b/tests/Atomizer.Tests/Configuration/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,38 @@
+using Atomizer.Processing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Atomizer.Tests.Configuration;
+
+public sealed class ServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddAtomizerProcessing_WhenJobRetentionIsNull_ShouldNotRegisterRetentionHostedService()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAtomizerProcessing();
+
+        services
+            .Should()
+            .NotContain(descriptor =>
+                descriptor.ServiceType == typeof(IHostedService)
+                && descriptor.ImplementationType == typeof(AtomizerJobRetentionService)
+            );
+    }
+
+    [Fact]
+    public void AddAtomizerProcessing_WhenJobRetentionIsConfigured_ShouldRegisterRetentionHostedService()
+    {
+        var services = new ServiceCollection();
+
+        services.AddAtomizerProcessing(options => options.JobRetention = TimeSpan.FromDays(7));
+
+        services
+            .Should()
+            .Contain(descriptor =>
+                descriptor.ServiceType == typeof(IHostedService)
+                && descriptor.ImplementationType == typeof(AtomizerJobRetentionService)
+            );
+    }
+}

--- a/tests/Atomizer.Tests/Processing/HeartbeatConfigurationTests.cs
+++ b/tests/Atomizer.Tests/Processing/HeartbeatConfigurationTests.cs
@@ -15,6 +15,8 @@ public sealed class HeartbeatConfigurationTests
         options.HeartbeatInterval.Should().Be(TimeSpan.FromSeconds(30));
         options.StaleServerTimeout.Should().Be(TimeSpan.FromMinutes(3));
         options.EffectiveStaleSweepInterval.Should().Be(options.HeartbeatInterval);
+        options.JobRetention.Should().BeNull();
+        options.JobRetentionSweepInterval.Should().Be(TimeSpan.FromHours(1));
     }
 
     [Fact]
@@ -29,6 +31,30 @@ public sealed class HeartbeatConfigurationTests
         var act = options.Validate;
 
         act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*six times*");
+    }
+
+    [Fact]
+    public void AtomizerProcessingOptions_WhenJobRetentionIsNotPositive_ShouldThrow()
+    {
+        var options = new AtomizerProcessingOptions { JobRetention = TimeSpan.Zero };
+
+        var act = options.Validate;
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*Job retention*positive*");
+    }
+
+    [Fact]
+    public void AtomizerProcessingOptions_WhenJobRetentionSweepIntervalIsNotPositive_ShouldThrow()
+    {
+        var options = new AtomizerProcessingOptions
+        {
+            JobRetention = TimeSpan.FromDays(7),
+            JobRetentionSweepInterval = TimeSpan.Zero,
+        };
+
+        var act = options.Validate;
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithMessage("*Job retention sweep interval*positive*");
     }
 
     [Fact]

--- a/tests/Atomizer.Tests/Processing/JobRetentionServiceTests.cs
+++ b/tests/Atomizer.Tests/Processing/JobRetentionServiceTests.cs
@@ -1,0 +1,95 @@
+using Atomizer.Abstractions;
+using Atomizer.Core;
+using Atomizer.Processing;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atomizer.Tests.Processing;
+
+public sealed class JobRetentionServiceTests
+{
+    [Fact]
+    public async Task ExecuteAsync_WhenRetentionIsConfigured_ShouldDeleteExpiredJobsUsingRetentionCutoff()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var retention = TimeSpan.FromDays(7);
+        var clock = Substitute.For<IAtomizerClock>();
+        clock.UtcNow.Returns(now);
+
+        var storage = Substitute.For<IAtomizerStorage>();
+        var cleanupAttempted = new TaskCompletionSource<DateTimeOffset>(
+            TaskCreationOptions.RunContinuationsAsynchronously
+        );
+        storage
+            .DeleteExpiredJobsAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                cleanupAttempted.TrySetResult(callInfo.Arg<DateTimeOffset>());
+                return 2;
+            });
+
+        var service = new AtomizerJobRetentionService(
+            new TestServiceScopeFactory(storage),
+            new AtomizerProcessingOptions
+            {
+                JobRetention = retention,
+                JobRetentionSweepInterval = TimeSpan.FromHours(1),
+            },
+            clock,
+            Substitute.For<TestableLogger<AtomizerJobRetentionService>>()
+        );
+        var executeAsync = NonPublicSpy.CreateFunc<AtomizerJobRetentionService, CancellationToken, Task>(
+            "ExecuteAsync"
+        );
+        using var cts = new CancellationTokenSource();
+
+        var run = executeAsync(service, cts.Token);
+
+        var cutoff = await cleanupAttempted.Task.WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken
+        );
+        cts.Cancel();
+
+        var awaitRun = async () => await run;
+        await awaitRun.Should().ThrowAsync<OperationCanceledException>();
+
+        cutoff.Should().Be(now - retention);
+        await storage.Received(1).DeleteExpiredJobsAsync(now - retention, Arg.Any<CancellationToken>());
+    }
+
+    private sealed class TestServiceScopeFactory : IServiceScopeFactory
+    {
+        private readonly IAtomizerStorage _storage;
+
+        public TestServiceScopeFactory(IAtomizerStorage storage)
+        {
+            _storage = storage;
+        }
+
+        public IServiceScope CreateScope() => new TestServiceScope(_storage);
+    }
+
+    private sealed class TestServiceScope : IServiceScope
+    {
+        public TestServiceScope(IAtomizerStorage storage)
+        {
+            ServiceProvider = new TestServiceProvider(storage);
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public void Dispose() { }
+    }
+
+    private sealed class TestServiceProvider : IServiceProvider
+    {
+        private readonly IAtomizerStorage _storage;
+
+        public TestServiceProvider(IAtomizerStorage storage)
+        {
+            _storage = storage;
+        }
+
+        public object? GetService(Type serviceType) => serviceType == typeof(IAtomizerStorage) ? _storage : null;
+    }
+}

--- a/tests/Atomizer.Tests/Processing/QueuePollerTests.cs
+++ b/tests/Atomizer.Tests/Processing/QueuePollerTests.cs
@@ -211,15 +211,31 @@ namespace Atomizer.Tests.Processing
         {
             // Arrange
             var channel = Channel.CreateUnbounded<JobBatch>();
+            var leaseAttemptCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            _storage
+                .ExecuteInLeaseAsync(
+                    Arg.Any<QueueKey>(),
+                    Arg.Any<Func<CancellationToken, Task<List<AtomizerJob>>>>(),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(async callInfo =>
+                {
+                    var callback = callInfo.ArgAt<Func<CancellationToken, Task<List<AtomizerJob>>>>(1);
+                    var jobs = await callback(CancellationToken.None);
+                    leaseAttemptCompleted.TrySetResult();
+                    return jobs;
+                });
             _storage
                 .GetDueJobsAsync(_queueOptions.QueueKey, _now, _queueOptions.BatchSize, Arg.Any<CancellationToken>())
                 .Returns(new List<AtomizerJob>());
 
-            var cts = new CancellationTokenSource();
-            cts.CancelAfter(100);
+            using var cts = new CancellationTokenSource();
 
             // Act
-            await _sut.RunAsync(_queueOptions, _leaseToken, channel, cts.Token);
+            var runTask = _sut.RunAsync(_queueOptions, _leaseToken, channel, cts.Token);
+            await leaseAttemptCompleted.Task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
+            cts.Cancel();
+            (await WaitOrTimeout(runTask, Timeout)).Should().BeTrue();
 
             // Assert
             _logger.Received().LogDebug($"Queue '{_queueOptions.QueueKey}' found no jobs to lease");

--- a/tests/Atomizer.Tests/Processing/QueuePumpTests.cs
+++ b/tests/Atomizer.Tests/Processing/QueuePumpTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using System.Threading.Channels;
+﻿using System.Threading.Channels;
 using Atomizer.Abstractions;
 using Atomizer.Core;
 using Atomizer.Processing;
@@ -112,14 +111,21 @@ public class QueuePumpTests
         var identity = new AtomizerRuntimeIdentity();
         var worker = Substitute.For<IJobWorker>();
         var clock = Substitute.For<IAtomizerClock>();
+        var workerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var executionCancelled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         workerFactory.Create(Arg.Any<QueueKey>(), Arg.Any<int>()).Returns(worker);
-        // Simulate a worker that takes 3 seconds to complete
         worker
             .RunAsync(Arg.Any<ChannelReader<JobBatch>>(), Arg.Any<CancellationToken>(), Arg.Any<CancellationToken>())
-            .Returns(async _ =>
+            .Returns(async call =>
             {
-                await Task.Delay(TimeSpan.FromSeconds(3));
+                var executionToken = call.ArgAt<CancellationToken>(2);
+                workerStarted.SetResult();
+                using var registration = executionToken.Register(() => executionCancelled.TrySetResult());
+                await executionCancelled.Task;
             });
+        storage
+            .ReleaseLeasedAsync(Arg.Any<LeaseToken>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .Returns(0);
         poller
             .RunAsync(
                 Arg.Any<QueueOptions>(),
@@ -131,16 +137,14 @@ public class QueuePumpTests
 
         var pump = new QueuePump(queueOptions, poller, storageScopeFactory, logger, workerFactory, identity, clock);
         pump.Start(CancellationToken.None);
+        await workerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Act
-        var sw = Stopwatch.StartNew();
-        await pump.StopAsync(TimeSpan.FromSeconds(1), CancellationToken.None);
-        sw.Stop();
+        await pump.StopAsync(TimeSpan.Zero, TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
-        // Assert: Should return after about 1 second, not 2
-        sw.Elapsed.TotalSeconds.Should().BeGreaterThanOrEqualTo(1);
-        sw.Elapsed.TotalSeconds.Should()
-            .BeLessThan(2, $"StopAsync should return after about 1 second, elapsed: {sw.Elapsed.TotalSeconds}");
+        // Assert
+        await executionCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         logger.Received(1).LogInformation($"Stopping queue '{queueOptions.QueueKey}'...");
         logger.Received(1).LogInformation($"Queue '{queueOptions.QueueKey}' stopped");

--- a/tests/Atomizer.Tests/Scheduling/SchedulerTests.cs
+++ b/tests/Atomizer.Tests/Scheduling/SchedulerTests.cs
@@ -21,11 +21,19 @@ public class SchedulerTests
     {
         // Arrange
         var token = CancellationToken.None;
+        var pollerStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _poller
+            .RunAsync(Arg.Any<CancellationToken>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                pollerStarted.SetResult();
+                return Task.CompletedTask;
+            });
 
         // Act
         _sut.Start(token);
 
-        await Task.Delay(50, TestContext.Current.CancellationToken); // Give some time for the async task to star
+        await pollerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
 
         // Assert
         _logger.Received(1).LogInformation("Starting Atomizer Scheduler");


### PR DESCRIPTION
## Summary
- Adds optional `JobRetention` processing config with a `null` default so jobs are retained forever unless configured.
- Registers a retention hosted service only when retention is enabled and sweeps expired terminal jobs on a configurable interval.
- Extends storage backends with terminal-job deletion and shared contract coverage.

## Changes
- Added `DeleteExpiredJobsAsync` to `IAtomizerStorage` and implemented it for in-memory and EF Core storage.
- Added option validation, conditional DI registration, retention service cutoff behavior, and storage contract tests.