### PR TITLE
feat(dashboard): add trigger examples and confirmations

### DIFF
--- a/src/Atomizer.Dashboard/Contracts/DashboardActionDtos.cs
+++ b/src/Atomizer.Dashboard/Contracts/DashboardActionDtos.cs
@@ -28,6 +28,7 @@ internal sealed class JobTypeOptionDto
     public string Id { get; init; } = string.Empty;
     public string PayloadTypeName { get; init; } = string.Empty;
     public string PayloadTypeFullName { get; init; } = string.Empty;
+    public string ExamplePayload { get; init; } = string.Empty;
 }
 
 internal sealed class SetScheduleEnabledRequest

--- a/src/Atomizer.Dashboard/Services/DashboardCommandService.cs
+++ b/src/Atomizer.Dashboard/Services/DashboardCommandService.cs
@@ -36,6 +36,7 @@ internal sealed class DashboardCommandService
                 Id = payloadType.AssemblyQualifiedName!,
                 PayloadTypeName = payloadType.Name,
                 PayloadTypeFullName = payloadType.FullName ?? payloadType.Name,
+                ExamplePayload = DashboardPayloadExampleFactory.Create(payloadType),
             })
             .ToList();
     }

--- a/src/Atomizer.Dashboard/Services/DashboardPayloadExampleFactory.cs
+++ b/src/Atomizer.Dashboard/Services/DashboardPayloadExampleFactory.cs
@@ -1,0 +1,149 @@
+using System.Collections;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Atomizer.Dashboard.Services;
+
+internal static class DashboardPayloadExampleFactory
+{
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerDefaults.Web) { WriteIndented = true };
+
+    public static string Create(Type payloadType)
+    {
+        var example = CreateValue(payloadType, new HashSet<Type>(), depth: 0);
+        return JsonSerializer.Serialize(example, Options);
+    }
+
+    private static object? CreateValue(Type type, HashSet<Type> stack, int depth)
+    {
+        var underlyingType = Nullable.GetUnderlyingType(type);
+        if (underlyingType is not null)
+        {
+            return CreateValue(underlyingType, stack, depth);
+        }
+
+        if (type == typeof(string) || type == typeof(char))
+            return string.Empty;
+        if (type == typeof(bool))
+            return false;
+        if (IsNumeric(type))
+            return Activator.CreateInstance(type);
+        if (type == typeof(Guid))
+            return Guid.Empty;
+        if (type == typeof(DateTimeOffset))
+            return DateTimeOffset.Parse("2026-01-01T00:00:00+00:00");
+        if (type == typeof(DateTime))
+            return DateTime.Parse("2026-01-01T00:00:00Z").ToUniversalTime();
+        if (type == typeof(TimeSpan))
+            return TimeSpan.Zero;
+        if (type.IsEnum)
+            return Enum.GetValues(type).Length == 0 ? 0 : Enum.GetValues(type).GetValue(0);
+
+        if (depth > 4 || !stack.Add(type))
+        {
+            return null;
+        }
+
+        try
+        {
+            if (TryCreateDictionary(type, stack, depth, out var dictionary))
+            {
+                return dictionary;
+            }
+
+            if (TryCreateEnumerable(type, stack, depth, out var enumerable))
+            {
+                return enumerable;
+            }
+
+            return CreateObject(type, stack, depth);
+        }
+        finally
+        {
+            stack.Remove(type);
+        }
+    }
+
+    private static Dictionary<string, object?> CreateObject(Type type, HashSet<Type> stack, int depth)
+    {
+        return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(property =>
+                property.GetIndexParameters().Length == 0
+                && property.GetMethod is not null
+                && property.GetCustomAttribute<JsonIgnoreAttribute>() is null
+            )
+            .OrderBy(property => property.MetadataToken)
+            .ToDictionary(GetJsonPropertyName, property => CreateValue(property.PropertyType, stack, depth + 1));
+    }
+
+    private static bool TryCreateEnumerable(Type type, HashSet<Type> stack, int depth, out object? enumerable)
+    {
+        enumerable = null;
+        if (type == typeof(string) || !typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            return false;
+        }
+
+        var elementType = GetEnumerableElementType(type);
+        enumerable = elementType is null ? Array.Empty<object>() : new[] { CreateValue(elementType, stack, depth + 1) };
+        return true;
+    }
+
+    private static bool TryCreateDictionary(Type type, HashSet<Type> stack, int depth, out object? dictionary)
+    {
+        dictionary = null;
+        var dictionaryType = type.GetInterfaces()
+            .Concat([type])
+            .FirstOrDefault(candidate =>
+                candidate.IsGenericType
+                && candidate.GetGenericTypeDefinition() == typeof(IDictionary<,>)
+                && candidate.GetGenericArguments()[0] == typeof(string)
+            );
+
+        if (dictionaryType is null)
+        {
+            return false;
+        }
+
+        var valueType = dictionaryType.GetGenericArguments()[1];
+        dictionary = new Dictionary<string, object?> { ["key"] = CreateValue(valueType, stack, depth + 1) };
+        return true;
+    }
+
+    private static Type? GetEnumerableElementType(Type type)
+    {
+        if (type.IsArray)
+        {
+            return type.GetElementType();
+        }
+
+        return type.GetInterfaces()
+            .Concat([type])
+            .FirstOrDefault(candidate =>
+                candidate.IsGenericType && candidate.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+            )
+            ?.GetGenericArguments()[0];
+    }
+
+    private static string GetJsonPropertyName(PropertyInfo property)
+    {
+        var explicitName = property.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name;
+        return explicitName ?? Options.PropertyNamingPolicy?.ConvertName(property.Name) ?? property.Name;
+    }
+
+    private static bool IsNumeric(Type type)
+    {
+        return type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong)
+            || type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal);
+    }
+}

--- a/src/Atomizer.Dashboard/frontend/src/api/hooks.ts
+++ b/src/Atomizer.Dashboard/frontend/src/api/hooks.ts
@@ -37,10 +37,11 @@ export function useJob(id: string) {
     });
 }
 
-export function useJobTypes() {
+export function useJobTypes(enabled = true) {
     return useQuery<JobTypeOption[]>({
         queryKey: ['jobTypes'],
         queryFn: api.getJobTypes,
+        enabled,
     });
 }
 

--- a/src/Atomizer.Dashboard/frontend/src/api/types.ts
+++ b/src/Atomizer.Dashboard/frontend/src/api/types.ts
@@ -59,6 +59,7 @@ export interface JobTypeOption {
     id: string;
     payloadTypeName: string;
     payloadTypeFullName: string;
+    examplePayload: string;
 }
 
 export interface TriggerJobRequest {

--- a/src/Atomizer.Dashboard/frontend/src/components/DashboardUi.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/components/DashboardUi.tsx
@@ -1,7 +1,8 @@
 import type { ReactNode } from 'react';
+import { useEffect } from 'react';
 import { formatAbsoluteDateTime, formatRelativeTime } from '../utils/time';
 
-type Tone = 'slate' | 'blue' | 'green' | 'red' | 'amber' | 'purple' | 'cyan';
+type Tone = 'slate' | 'blue' | 'green' | 'red' | 'amber' | 'purple' | 'cyan' | 'orange';
 
 const toneClasses: Record<Tone, string> = {
     slate: 'status-pill--slate',
@@ -11,6 +12,7 @@ const toneClasses: Record<Tone, string> = {
     amber: 'status-pill--amber',
     purple: 'status-pill--purple',
     cyan: 'status-pill--cyan',
+    orange: 'status-pill--orange',
 };
 
 const statusTones: Record<string, Tone> = {
@@ -18,7 +20,7 @@ const statusTones: Record<string, Tone> = {
     Processing: 'blue',
     Completed: 'green',
     Failed: 'red',
-    Cancelled: 'slate',
+    Cancelled: 'orange',
     Enabled: 'green',
     Disabled: 'slate',
     Healthy: 'green',
@@ -132,6 +134,7 @@ export function MetricCard({
         amber: 'from-amber-300 to-orange-500',
         purple: 'from-violet-400 to-fuchsia-600',
         cyan: 'from-cyan-300 to-sky-500',
+        orange: 'from-orange-300 to-orange-600',
     };
 
     return (
@@ -166,6 +169,68 @@ export function StatusPill({ status, tone, className }: { status: string; tone?:
             <span className="mr-1.5 h-1.5 w-1.5 rounded-full bg-current opacity-70" />
             {status}
         </span>
+    );
+}
+
+export function ConfirmationDialog({
+    open,
+    title,
+    description,
+    confirmLabel,
+    onConfirm,
+    onCancel,
+    confirmTone = 'default',
+}: {
+    open: boolean;
+    title: string;
+    description: ReactNode;
+    confirmLabel: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+    confirmTone?: 'default' | 'danger';
+}) {
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onCancel();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [onCancel, open]);
+
+    if (!open) {
+        return null;
+    }
+
+    return (
+        <div
+            aria-modal="true"
+            className="dialog-backdrop fixed inset-0 z-50 flex items-center justify-center p-4"
+            role="dialog"
+        >
+            <div className="dialog-panel w-full max-w-md rounded-2xl border p-5 shadow-2xl">
+                <h2 className="text-strong text-base font-semibold">{title}</h2>
+                <div className="text-muted mt-2 text-sm leading-6">{description}</div>
+                <div className="mt-5 flex flex-wrap justify-end gap-2">
+                    <button type="button" className={ui.secondaryButton} onClick={onCancel}>
+                        Keep current state
+                    </button>
+                    <button
+                        type="button"
+                        className={confirmTone === 'danger' ? 'danger-button rounded-2xl px-4 py-2 text-sm font-semibold transition' : ui.primaryButton}
+                        onClick={onConfirm}
+                    >
+                        {confirmLabel}
+                    </button>
+                </div>
+            </div>
+        </div>
     );
 }
 

--- a/src/Atomizer.Dashboard/frontend/src/index.css
+++ b/src/Atomizer.Dashboard/frontend/src/index.css
@@ -106,7 +106,9 @@ body {
 }
 
 button,
-input {
+input,
+select,
+textarea {
     font: inherit;
 }
 
@@ -116,14 +118,18 @@ button:not(:disabled) {
 
 button:focus-visible,
 a:focus-visible,
-input:focus-visible {
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
     outline: 2px solid #38bdf8;
     outline-offset: 3px;
 }
 
 [data-theme="light"] button:focus-visible,
 [data-theme="light"] a:focus-visible,
-[data-theme="light"] input:focus-visible {
+[data-theme="light"] input:focus-visible,
+[data-theme="light"] select:focus-visible,
+[data-theme="light"] textarea:focus-visible {
     outline-color: #0284c7;
 }
 
@@ -344,6 +350,16 @@ input:focus-visible {
     filter: brightness(0.96);
 }
 
+.danger-button {
+    background: var(--danger-strong);
+    color: var(--page-background);
+    box-shadow: 0 14px 32px var(--shadow);
+}
+
+.danger-button:hover {
+    filter: brightness(0.96);
+}
+
 .button-secondary:hover,
 .filter-chip:hover {
     border-color: var(--border);
@@ -469,6 +485,10 @@ input:focus-visible {
     color: #94a3b8;
 }
 
+.count-orange {
+    color: #fb923c;
+}
+
 [data-theme="light"] .count-amber {
     color: #d97706;
 }
@@ -487,6 +507,21 @@ input:focus-visible {
 
 [data-theme="light"] .count-slate {
     color: #475569;
+}
+
+[data-theme="light"] .count-orange {
+    color: #ea580c;
+}
+
+.dialog-backdrop {
+    background: rgba(2, 6, 23, 0.72);
+    backdrop-filter: blur(10px);
+}
+
+.dialog-panel {
+    border-color: var(--border);
+    background: var(--panel-solid);
+    color: var(--text);
 }
 
 .status-pill {
@@ -544,6 +579,12 @@ input:focus-visible {
     --tone-border: rgba(34, 211, 238, 0.28);
 }
 
+.status-pill--orange {
+    --tone-bg: rgba(249, 115, 22, 0.18);
+    --tone-text: #fed7aa;
+    --tone-border: rgba(251, 146, 60, 0.3);
+}
+
 [data-theme="light"] .status-pill--slate {
     --tone-bg: #f1f5f9;
     --tone-text: #475569;
@@ -584,4 +625,10 @@ input:focus-visible {
     --tone-bg: #cffafe;
     --tone-text: #0e7490;
     --tone-border: #a5f3fc;
+}
+
+[data-theme="light"] .status-pill--orange {
+    --tone-bg: #ffedd5;
+    --tone-text: #c2410c;
+    --tone-border: #fed7aa;
 }

--- a/src/Atomizer.Dashboard/frontend/src/views/JobDetail.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/JobDetail.tsx
@@ -1,9 +1,11 @@
 import { Link, useParams } from 'react-router-dom';
+import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { api } from '../api/client';
 import { useJob } from '../api/hooks';
 import { routePrefix } from '../config';
 import {
+    ConfirmationDialog,
     cx,
     MetricCard,
     MetricCardSkeleton,
@@ -21,6 +23,7 @@ export default function JobDetail() {
     const queryClient = useQueryClient();
     const now = useNow(15_000);
     const { data: job, isLoading, error } = useJob(id!);
+    const [confirmation, setConfirmation] = useState<'retry' | 'cancel' | null>(null);
     const refreshJobQueries = () => {
         queryClient.invalidateQueries({ queryKey: ['job', id] });
         queryClient.invalidateQueries({ queryKey: ['jobs'] });
@@ -65,7 +68,7 @@ export default function JobDetail() {
                                 type="button"
                                 className={ui.primaryButton}
                                 disabled={retryMutation.isPending}
-                                onClick={() => retryMutation.mutate(job.id)}
+                                onClick={() => setConfirmation('retry')}
                             >
                                 {retryMutation.isPending ? 'Retrying…' : 'Retry'}
                             </button>
@@ -75,7 +78,7 @@ export default function JobDetail() {
                                 type="button"
                                 className={ui.secondaryButton}
                                 disabled={cancelMutation.isPending}
-                                onClick={() => cancelMutation.mutate(job.id)}
+                                onClick={() => setConfirmation('cancel')}
                             >
                                 {cancelMutation.isPending ? 'Cancelling…' : 'Cancel'}
                             </button>
@@ -117,9 +120,31 @@ export default function JobDetail() {
                     label={finalLabel}
                     value={<RelativeTime value={finalTimestamp} now={now} />}
                     helper="Most relevant transition"
-                    tone={job.status === 'Failed' ? 'red' : job.status === 'Completed' ? 'green' : job.status === 'Cancelled' ? 'slate' : 'purple'}
+                    tone={job.status === 'Failed' ? 'red' : job.status === 'Completed' ? 'green' : job.status === 'Cancelled' ? 'orange' : 'purple'}
                 />
             </div>
+
+            <ConfirmationDialog
+                open={confirmation !== null}
+                title={confirmation === 'cancel' ? 'Cancel job?' : 'Retry job?'}
+                description={
+                    confirmation === 'cancel'
+                        ? `Cancel pending job ${job.id.slice(0, 8)}. This moves it out of the queue.`
+                        : `Retry failed job ${job.id.slice(0, 8)} by enqueueing a replacement job.`
+                }
+                confirmLabel={confirmation === 'cancel' ? 'Cancel job' : 'Retry job'}
+                confirmTone={confirmation === 'cancel' ? 'danger' : 'default'}
+                onCancel={() => setConfirmation(null)}
+                onConfirm={() => {
+                    if (confirmation === 'cancel') {
+                        cancelMutation.mutate(job.id);
+                    } else if (confirmation === 'retry') {
+                        retryMutation.mutate(job.id);
+                    }
+
+                    setConfirmation(null);
+                }}
+            />
 
             <Panel>
                 <div className={ui.panelHeadingAccent}>

--- a/src/Atomizer.Dashboard/frontend/src/views/JobsList.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/JobsList.tsx
@@ -5,8 +5,9 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { api } from '../api/client';
 import { useJobs, useJobTypes, type JobFilters } from '../api/hooks';
 import { routePrefix, jobsRefreshMs } from '../config';
-import type { JobDto } from '../api/types';
+import type { JobDto, JobTypeOption } from '../api/types';
 import {
+    ConfirmationDialog,
     cx,
     EmptyState,
     formatNumber,
@@ -34,6 +35,11 @@ const TIME_FILTERS = [
     { key: '7d', label: '7d', getFrom: () => new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString() },
 ] as const;
 
+type JobsConfirmation =
+    | { action: 'trigger'; payloadTypeId: string; payloadTypeName: string; queueKey: string; payload: string }
+    | { action: 'retry'; job: JobDto }
+    | { action: 'cancel'; job: JobDto };
+
 export default function JobsList() {
     const [searchParams] = useSearchParams();
     const navigate = useNavigate();
@@ -42,7 +48,8 @@ export default function JobsList() {
     const [isTriggerOpen, setIsTriggerOpen] = useState(false);
     const [triggerPayloadTypeId, setTriggerPayloadTypeId] = useState('');
     const [triggerQueueKey, setTriggerQueueKey] = useState(QueueKeyDefault);
-    const [triggerPayload, setTriggerPayload] = useState('{\n  "message": ""\n}');
+    const [triggerPayload, setTriggerPayload] = useState('');
+    const [confirmation, setConfirmation] = useState<JobsConfirmation | null>(null);
     const [timeFilter, setTimeFilter] = useState<(typeof TIME_FILTERS)[number]['key']>('all');
     const [filters, setFilters] = useState<JobFilters>(() => ({
         skip: 0,
@@ -56,7 +63,7 @@ export default function JobsList() {
     const debouncedQueueSearch = useDebouncedValue(queueSearch, 300);
     const debouncedPayloadSearch = useDebouncedValue(payloadSearch, 300);
     const { data, isLoading, error, refetch, dataUpdatedAt, isFetching } = useJobs(filters);
-    const { data: jobTypes = [] } = useJobTypes();
+    const { data: jobTypes = [], isLoading: isLoadingJobTypes, error: jobTypesError } = useJobTypes(isTriggerOpen);
     const counts = data?.statusCounts ?? { pending: 0, processing: 0, completed: 0, failed: 0, cancelled: 0 };
     const retryMutation = useMutation({
         mutationFn: api.retryJob,
@@ -81,6 +88,10 @@ export default function JobsList() {
 
     const setPage = (skip: number) => setFilters(f => ({ ...f, skip }));
     const openJob = (jobId: string) => navigate(`${routePrefix}/jobs/${jobId}`);
+    const selectTriggerPayloadType = (option: JobTypeOption) => {
+        setTriggerPayloadTypeId(option.id);
+        setTriggerPayload(option.examplePayload);
+    };
 
     useEffect(() => {
         setFilters(f => ({
@@ -92,10 +103,10 @@ export default function JobsList() {
     }, [debouncedPayloadSearch, debouncedQueueSearch]);
 
     useEffect(() => {
-        if (!triggerPayloadTypeId && jobTypes.length > 0) {
-            setTriggerPayloadTypeId(jobTypes[0].id);
+        if (isTriggerOpen && !triggerPayloadTypeId && jobTypes.length > 0) {
+            selectTriggerPayloadType(jobTypes[0]);
         }
-    }, [jobTypes, triggerPayloadTypeId]);
+    }, [isTriggerOpen, jobTypes, triggerPayloadTypeId]);
 
     const handleRowKeyDown = (event: KeyboardEvent<HTMLTableRowElement>, jobId: string) => {
         if (event.key === 'Enter' || event.key === ' ') {
@@ -109,8 +120,11 @@ export default function JobsList() {
 
     const submitTriggerJob = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
-        triggerMutation.mutate({
+        const selectedJobType = jobTypes.find(option => option.id === triggerPayloadTypeId);
+        setConfirmation({
+            action: 'trigger',
             payloadTypeId: triggerPayloadTypeId,
+            payloadTypeName: selectedJobType?.payloadTypeName ?? 'selected payload type',
             queueKey: triggerQueueKey,
             payload: triggerPayload,
         });
@@ -150,7 +164,7 @@ export default function JobsList() {
                         <button
                             onClick={() => setIsTriggerOpen(open => !open)}
                             className={ui.secondaryButton}
-                            disabled={jobTypes.length === 0}
+                            aria-expanded={isTriggerOpen}
                         >
                             Trigger job
                         </button>
@@ -166,8 +180,18 @@ export default function JobsList() {
                             <select
                                 className={ui.input}
                                 value={triggerPayloadTypeId}
-                                onChange={event => setTriggerPayloadTypeId(event.target.value)}
+                                disabled={isLoadingJobTypes || jobTypes.length === 0}
+                                onChange={event => {
+                                    const selected = jobTypes.find(option => option.id === event.target.value);
+                                    if (selected) {
+                                        selectTriggerPayloadType(selected);
+                                    }
+                                }}
                             >
+                                {isLoadingJobTypes && <option value="">Loading payload types</option>}
+                                {!isLoadingJobTypes && jobTypes.length === 0 && (
+                                    <option value="">No registered payload types</option>
+                                )}
                                 {jobTypes.map(option => (
                                     <option key={option.id} value={option.id}>
                                         {option.payloadTypeFullName}
@@ -191,9 +215,16 @@ export default function JobsList() {
                             <textarea
                                 className="input-field mt-2 h-44 w-full rounded-2xl border px-4 py-3 font-mono text-sm outline-none transition"
                                 value={triggerPayload}
+                                disabled={isLoadingJobTypes || jobTypes.length === 0}
                                 onChange={event => setTriggerPayload(event.target.value)}
                             />
                         </label>
+
+                        {jobTypesError && (
+                            <div className="danger-text text-sm font-medium xl:col-span-2">
+                                Failed to load payload types.
+                            </div>
+                        )}
 
                         {triggerMutation.error && (
                             <div className="danger-text text-sm font-medium xl:col-span-2">
@@ -205,7 +236,7 @@ export default function JobsList() {
                             <button
                                 type="submit"
                                 className={ui.primaryButton}
-                                disabled={triggerMutation.isPending || !triggerPayloadTypeId}
+                                disabled={triggerMutation.isPending || isLoadingJobTypes || !triggerPayloadTypeId}
                             >
                                 {triggerMutation.isPending ? 'Triggering…' : 'Trigger'}
                             </button>
@@ -220,6 +251,34 @@ export default function JobsList() {
                     </form>
                 </Panel>
             )}
+
+            <ConfirmationDialog
+                open={confirmation !== null}
+                title={getJobsConfirmationTitle(confirmation)}
+                description={getJobsConfirmationDescription(confirmation)}
+                confirmLabel={getJobsConfirmationLabel(confirmation)}
+                confirmTone={confirmation?.action === 'cancel' ? 'danger' : 'default'}
+                onCancel={() => setConfirmation(null)}
+                onConfirm={() => {
+                    if (!confirmation) {
+                        return;
+                    }
+
+                    if (confirmation.action === 'trigger') {
+                        triggerMutation.mutate({
+                            payloadTypeId: confirmation.payloadTypeId,
+                            queueKey: confirmation.queueKey,
+                            payload: confirmation.payload,
+                        });
+                    } else if (confirmation.action === 'retry') {
+                        retryMutation.mutate(confirmation.job.id);
+                    } else {
+                        cancelMutation.mutate(confirmation.job.id);
+                    }
+
+                    setConfirmation(null);
+                }}
+            />
 
             <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
                 {isLoading ? (
@@ -423,7 +482,7 @@ export default function JobsList() {
                                                             onKeyDown={stopRowKeyboardAction}
                                                             onClick={event => {
                                                                 stopRowAction(event);
-                                                                retryMutation.mutate(job.id);
+                                                                setConfirmation({ action: 'retry', job });
                                                             }}
                                                         >
                                                             Retry
@@ -437,7 +496,7 @@ export default function JobsList() {
                                                             onKeyDown={stopRowKeyboardAction}
                                                             onClick={event => {
                                                                 stopRowAction(event);
-                                                                cancelMutation.mutate(job.id);
+                                                                setConfirmation({ action: 'cancel', job });
                                                             }}
                                                         >
                                                             Cancel
@@ -489,6 +548,46 @@ export default function JobsList() {
             </Panel>
         </div>
     );
+}
+
+function getJobsConfirmationTitle(confirmation: JobsConfirmation | null): string {
+    if (confirmation?.action === 'trigger') {
+        return 'Trigger job?';
+    }
+
+    if (confirmation?.action === 'retry') {
+        return 'Retry job?';
+    }
+
+    return 'Cancel job?';
+}
+
+function getJobsConfirmationDescription(confirmation: JobsConfirmation | null): string {
+    if (confirmation?.action === 'trigger') {
+        return `Trigger ${confirmation.payloadTypeName} on queue ${confirmation.queueKey}.`;
+    }
+
+    if (confirmation?.action === 'retry') {
+        return `Retry failed job ${confirmation.job.id.slice(0, 8)} by enqueueing a replacement job.`;
+    }
+
+    if (confirmation?.action === 'cancel') {
+        return `Cancel pending job ${confirmation.job.id.slice(0, 8)}. This moves it out of the queue.`;
+    }
+
+    return '';
+}
+
+function getJobsConfirmationLabel(confirmation: JobsConfirmation | null): string {
+    if (confirmation?.action === 'trigger') {
+        return 'Trigger job';
+    }
+
+    if (confirmation?.action === 'retry') {
+        return 'Retry job';
+    }
+
+    return 'Cancel job';
 }
 
 function JobTiming({ job, now }: { job: JobDto; now: number }) {

--- a/src/Atomizer.Dashboard/frontend/src/views/QueueStats.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/QueueStats.tsx
@@ -131,13 +131,13 @@ export default function QueueStats() {
                                                 <CountCell value={queue.processing} tone="count-sky" />
                                                 <CountCell value={queue.completed} tone="count-emerald" />
                                                 <CountCell value={queue.failed} tone="count-rose" />
-                                                <CountCell value={queue.cancelled} tone="count-slate" />
+                                                <CountCell value={queue.cancelled} tone="count-orange" />
                                                 <td className="px-5 py-4">
                                                     <div className="flex h-2 w-40 overflow-hidden rounded-full bg-[var(--chip)]">
                                                         <WorkMixSegment value={queue.pending} total={total} className="bg-amber-400" />
                                                         <WorkMixSegment value={queue.processing} total={total} className="bg-sky-400" />
                                                         <WorkMixSegment value={queue.failed} total={total} className="bg-rose-400" />
-                                                        <WorkMixSegment value={queue.cancelled} total={total} className="bg-slate-400" />
+                                                        <WorkMixSegment value={queue.cancelled} total={total} className="bg-orange-400" />
                                                         <WorkMixSegment value={queue.completed} total={total} className="bg-emerald-400" />
                                                     </div>
                                                     <div className={cx(ui.soft, 'mt-1 text-xs')}>{formatNumber(total)} total</div>

--- a/src/Atomizer.Dashboard/frontend/src/views/SchedulesList.tsx
+++ b/src/Atomizer.Dashboard/frontend/src/views/SchedulesList.tsx
@@ -1,10 +1,13 @@
 import type { KeyboardEvent, MouseEvent } from 'react';
+import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import { useSchedules } from '../api/hooks';
 import { routePrefix, statsRefreshMs } from '../config';
+import type { ScheduleDto } from '../api/types';
 import {
+    ConfirmationDialog,
     EmptyState,
     formatNumber,
     MetricCard,
@@ -19,11 +22,16 @@ import {
 } from '../components/DashboardUi';
 import { useNow } from '../hooks/useNow';
 
+type ScheduleConfirmation =
+    | { action: 'toggle'; schedule: ScheduleDto }
+    | { action: 'runNow'; schedule: ScheduleDto };
+
 export default function SchedulesList() {
     const { data, isLoading, error, dataUpdatedAt } = useSchedules();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const now = useNow(1_000);
+    const [confirmation, setConfirmation] = useState<ScheduleConfirmation | null>(null);
     const invalidateScheduleActions = () => {
         queryClient.invalidateQueries({ queryKey: ['schedules'] });
         queryClient.invalidateQueries({ queryKey: ['jobs'] });
@@ -177,10 +185,7 @@ export default function SchedulesList() {
                                                         onKeyDown={stopRowKeyboardAction}
                                                         onClick={event => {
                                                             stopRowAction(event);
-                                                            toggleMutation.mutate({
-                                                                id: schedule.id,
-                                                                enabled: !schedule.enabled,
-                                                            });
+                                                            setConfirmation({ action: 'toggle', schedule });
                                                         }}
                                                     >
                                                         {schedule.enabled ? 'Disable' : 'Enable'}
@@ -192,7 +197,7 @@ export default function SchedulesList() {
                                                         onKeyDown={stopRowKeyboardAction}
                                                         onClick={event => {
                                                             stopRowAction(event);
-                                                            runNowMutation.mutate(schedule.id);
+                                                            setConfirmation({ action: 'runNow', schedule });
                                                         }}
                                                     >
                                                         Run now
@@ -214,8 +219,67 @@ export default function SchedulesList() {
                     </>
                 )}
             </Panel>
+
+            <ConfirmationDialog
+                open={confirmation !== null}
+                title={getScheduleConfirmationTitle(confirmation)}
+                description={getScheduleConfirmationDescription(confirmation)}
+                confirmLabel={getScheduleConfirmationLabel(confirmation)}
+                confirmTone={
+                    confirmation?.action === 'toggle' && confirmation.schedule.enabled ? 'danger' : 'default'
+                }
+                onCancel={() => setConfirmation(null)}
+                onConfirm={() => {
+                    if (!confirmation) {
+                        return;
+                    }
+
+                    if (confirmation.action === 'toggle') {
+                        toggleMutation.mutate({
+                            id: confirmation.schedule.id,
+                            enabled: !confirmation.schedule.enabled,
+                        });
+                    } else {
+                        runNowMutation.mutate(confirmation.schedule.id);
+                    }
+
+                    setConfirmation(null);
+                }}
+            />
         </div>
     );
+}
+
+function getScheduleConfirmationTitle(confirmation: ScheduleConfirmation | null): string {
+    if (confirmation?.action === 'runNow') {
+        return 'Run schedule now?';
+    }
+
+    return confirmation?.schedule.enabled ? 'Disable schedule?' : 'Enable schedule?';
+}
+
+function getScheduleConfirmationDescription(confirmation: ScheduleConfirmation | null): string {
+    if (confirmation?.action === 'runNow') {
+        return `Create a job for ${confirmation.schedule.jobKey} immediately.`;
+    }
+
+    if (confirmation?.action === 'toggle' && confirmation.schedule.enabled) {
+        return `Disable ${confirmation.schedule.jobKey}. Future runs will stop until it is enabled again.`;
+    }
+
+    if (confirmation?.action === 'toggle') {
+        return `Enable ${confirmation.schedule.jobKey}. Future runs can be enqueued again.`;
+    }
+
+    return '';
+}
+
+function getScheduleConfirmationLabel(confirmation: ScheduleConfirmation | null): string {
+    if (confirmation?.action === 'runNow') {
+        return 'Run now';
+    }
+
+    return confirmation?.schedule.enabled ? 'Disable schedule' : 'Enable schedule';
 }
 
 function getLastRunDisplayValue(lastRunAt: string | null, latestKnownRefreshAt: number): string | number | null {

--- a/tests/Atomizer.Dashboard.Tests/Endpoints/JobsEndpointsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Endpoints/JobsEndpointsTests.cs
@@ -221,6 +221,15 @@ public class JobsEndpointsTests : IClassFixture<DashboardTestHost>
             .NotBeNull()
             .And.ContainSingle(o => o.PayloadTypeName == nameof(DashboardActionPayload))
             .Subject;
+        option
+            .ExamplePayload.Should()
+            .Be(
+                """
+                {
+                  "message": ""
+                }
+                """
+            );
 
         var response = await client.PostAsJsonAsync(
             "/atomizer/api/jobs/trigger",
@@ -345,6 +354,7 @@ internal sealed class JobTypeOptionDto
     public string Id { get; init; } = string.Empty;
     public string PayloadTypeName { get; init; } = string.Empty;
     public string PayloadTypeFullName { get; init; } = string.Empty;
+    public string ExamplePayload { get; init; } = string.Empty;
 }
 
 internal sealed class JobErrorItemDto


### PR DESCRIPTION
## Summary
- Add lazy job-type loading so payload metadata is fetched only when the trigger panel opens.
- Include generated example payloads in job-type API responses and prefill the trigger payload editor.
- Add confirmation dialogs for dashboard mutation actions and make cancelled status orange.

## Changes
- Introduced `DashboardPayloadExampleFactory` and updated the job-type DTO/test coverage.
- Routed job trigger, retry, cancel, schedule toggle, and run-now actions through a shared `ConfirmationDialog`.
- Updated cancelled status/count styling from slate/grey to orange.