### PR TITLE
feat(client): add job control actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,6 @@ builder.Services.AddAtomizer(options =>
 
 Redis storage implements the same `IAtomizerStorage` monitoring methods as the other backends, so it works with `Atomizer.Dashboard` without referencing the dashboard package from `Atomizer.Redis`.
 
-The sample projects include `.http` files with example requests for enqueueing jobs, executing handlers directly, dequeuing pending jobs, and deleting recurring schedules:
-
-- `samples/Atomizer.Example/Atomizer.Example.http`
-- `samples/Atomizer.EFCore.Example/Atomizer.EFCore.Example.http`
-- `samples/Atomizer.Redis.Example/Atomizer.Redis.Example.http`
 
 ### 3. Define a Job Handler
 Create a handler for your job payload:

--- a/README.md
+++ b/README.md
@@ -118,15 +118,6 @@ builder.Services.AddAtomizer(options =>
 
 Redis storage implements the same `IAtomizerStorage` monitoring methods as the other backends, so it works with `Atomizer.Dashboard` without referencing the dashboard package from `Atomizer.Redis`.
 
-The Redis sample includes the dashboard and a few endpoints for creating and operating on jobs:
-
-```bash
-docker compose up -d redis
-dotnet run --project samples/Atomizer.Redis.Example/Atomizer.Redis.Example.csproj
-```
-
-Open `http://localhost:5053/atomizer` to inspect Redis-backed jobs, schedules, queues, and workers.
-
 The sample projects include `.http` files with example requests for enqueueing jobs, executing handlers directly, dequeuing pending jobs, and deleting recurring schedules:
 
 - `samples/Atomizer.Example/Atomizer.Example.http`

--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ Atomizer is a modern, high-performance job scheduling and queueing framework for
 - ⏳ **Visibility Timeout** — Prevent job duplication by locking jobs during processing.
 - 🕒 **FIFO Partitioned Processing** — Guarantee strict in-order, one-at-a-time execution per partition key (e.g. per customer, per entity).
 - 🧪 **In-Memory Driver** — Perfect for local development and testing; spin up queues instantly with zero setup.
-- 📈 **Dashboard** — Optional read-only dashboard for jobs, schedules, queue statistics, and worker heartbeats.
+- 📈 **Dashboard** — Optional operational dashboard for jobs, schedules, queue statistics, worker heartbeats, and built-in job/schedule actions.
 - 🔔 **ASP.NET Core Integration** — Works with DI, logging, and modern C# idioms.
+
+The dashboard gives teams a focused operational view of Atomizer: inspect queue health, review job and schedule details, watch active workers, and trigger common actions without building a custom admin UI.
+
+![Atomizer Dashboard jobs view](assets/atomizer-dashboard-logo-branding-dark.png)
 
 ## Quick Start
 Get up and running in minutes:
@@ -114,7 +118,7 @@ builder.Services.AddAtomizer(options =>
 
 Redis storage implements the same `IAtomizerStorage` monitoring methods as the other backends, so it works with `Atomizer.Dashboard` without referencing the dashboard package from `Atomizer.Redis`.
 
-The Redis sample includes the dashboard and a few endpoints for creating jobs:
+The Redis sample includes the dashboard and a few endpoints for creating and operating on jobs:
 
 ```bash
 docker compose up -d redis
@@ -122,6 +126,12 @@ dotnet run --project samples/Atomizer.Redis.Example/Atomizer.Redis.Example.cspro
 ```
 
 Open `http://localhost:5053/atomizer` to inspect Redis-backed jobs, schedules, queues, and workers.
+
+The sample projects include `.http` files with example requests for enqueueing jobs, executing handlers directly, dequeuing pending jobs, and deleting recurring schedules:
+
+- `samples/Atomizer.Example/Atomizer.Example.http`
+- `samples/Atomizer.EFCore.Example/Atomizer.EFCore.Example.http`
+- `samples/Atomizer.Redis.Example/Atomizer.Redis.Example.http`
 
 ### 3. Define a Job Handler
 Create a handler for your job payload:
@@ -146,7 +156,7 @@ public class SendNewsletterJob(INewsletterService newsletterService, IEmailServi
 }
 ```
 
-### 4. Enqueue or schedule a Job
+### 4. Enqueue, schedule, execute, or dequeue a Job
 Add jobs to the queue from your application code:
 ```csharp
 app.MapPost(
@@ -163,6 +173,22 @@ app.MapPost(
     }
 );
 ```
+
+Use `ExecuteAsync` when the job should run immediately in the current process but still be recorded in Atomizer as completed or failed:
+
+```csharp
+var jobId = await atomizerClient.ExecuteAsync(new SendNewsletterCommand(product));
+```
+
+If the handler throws, Atomizer records the job as failed and then rethrows the exception to the caller.
+
+Use `DequeueAsync` to cancel a job that is still pending:
+
+```csharp
+var dequeued = await atomizerClient.DequeueAsync(jobId);
+```
+
+It returns `false` when the job does not exist or is no longer pending.
 
 ### 5. FIFO Processing (Partitioned Jobs)
 To guarantee jobs for the same entity execute one-at-a-time in enqueue order, assign a `PartitionKey`:
@@ -191,6 +217,10 @@ await atomizer.ScheduleRecurringAsync(
     Schedule.Every(2).Minutes()
 );
 
+// Later, when the recurring schedule should stop:
+// safe to call even when the schedule has already been deleted or never existed.
+await atomizer.DeleteRecurringAsync("LoggerJob");
+
 ...
 ```
 
@@ -203,9 +233,7 @@ var app = builder.Build();
 app.MapAtomizerDashboard("/atomizer");
 ```
 
-Then browse to `/atomizer` to inspect jobs, job details, schedules, queue statistics, and active worker heartbeats. The dashboard is read-only in the current release; it does not retry, cancel, or dead-letter jobs.
-
-![Atomizer Dashboard jobs view](assets/atomizer-dashboard-logo-branding-dark.png)
+Then browse to `/atomizer` to inspect jobs, job details, schedules, queue statistics, and active worker heartbeats. The dashboard also includes operational actions such as triggering registered job types, retrying failed jobs, cancelling pending jobs, enabling or disabling schedules, and running schedules immediately.
 
 If no authorization filters are configured, dashboard requests are restricted to localhost by default. Add an `IAtomizerDashboardAuthorizationFilter` through `AddAtomizerDashboard(options => options.Authorization.Add(...))` before exposing it outside local development.
 

--- a/samples/Atomizer.EFCore.Example/Atomizer.EFCore.Example.http
+++ b/samples/Atomizer.EFCore.Example/Atomizer.EFCore.Example.http
@@ -1,6 +1,53 @@
 @Atomizer.EFCore.Example_HostAddress = http://localhost:5052
+@ProductId = 11111111-1111-1111-1111-111111111111
+@PendingJobId = 00000000-0000-0000-0000-000000000000
 
-GET {{Atomizer.EFCore.Example_HostAddress}}/weatherforecast/
+POST {{Atomizer.EFCore.Example_HostAddress}}/products
 Accept: application/json
 
 ###
+
+POST {{Atomizer.EFCore.Example_HostAddress}}/assign-stock
+Content-Type: application/json
+
+{
+  "productId": "{{ProductId}}",
+  "quantity": 25
+}
+
+###
+
+POST {{Atomizer.EFCore.Example_HostAddress}}/execute/log
+Accept: application/json
+
+###
+
+POST {{Atomizer.EFCore.Example_HostAddress}}/stock-events
+Content-Type: application/json
+
+{
+  "productId": "{{ProductId}}",
+  "eventType": "Restocked",
+  "delta": 25
+}
+
+###
+
+POST {{Atomizer.EFCore.Example_HostAddress}}/long-running-job
+Content-Type: application/json
+
+{
+  "durationInSeconds": 10
+}
+
+###
+
+# Replace @PendingJobId with a job id returned by a scheduled or enqueued request before it is picked up.
+DELETE {{Atomizer.EFCore.Example_HostAddress}}/jobs/{{PendingJobId}}
+Accept: application/json
+
+###
+
+# Idempotent: returns no content even when the recurring schedule is already gone.
+DELETE {{Atomizer.EFCore.Example_HostAddress}}/recurring/LoggerJob
+Accept: application/json

--- a/samples/Atomizer.EFCore.Example/Program.cs
+++ b/samples/Atomizer.EFCore.Example/Program.cs
@@ -68,21 +68,34 @@ await using var sqlServer = scope.ServiceProvider.GetRequiredService<ExampleSqlS
 await Task.WhenAll(postgres.Database.MigrateAsync(), mysql.Database.MigrateAsync(), sqlServer.Database.MigrateAsync());
 
 var atomizer = app.Services.GetRequiredService<IAtomizerClient>();
+const string recurringLoggerJob = "LoggerJob";
+const string recurringLoggerCatchUpJob = "LoggerJobCatchUp";
 
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
-    "LoggerJob",
+    recurringLoggerJob,
     Schedule.Every(2).Minutes()
 );
 
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
-    "LoggerJobCatchUp",
+    recurringLoggerCatchUpJob,
     Schedule.Cron("0/5 * * * * *"), // Every 5 seconds,
     options =>
     {
         options.MisfirePolicy = MisfirePolicy.CatchUp;
         options.PartitionKey = new PartitionKey("LoggerJobCatchUp");
+    }
+);
+
+app.MapPost(
+    "/execute/log",
+    async ([FromServices] IAtomizerClient atomizerClient) =>
+    {
+        var jobId = await atomizerClient.ExecuteAsync(
+            new LoggerJobPayload("Executed immediately from the EF Core sample API", LogLevel.Information)
+        );
+        return Results.Ok(new { jobId });
     }
 );
 
@@ -162,6 +175,26 @@ app.MapPost(
             options => options.PartitionKey = new PartitionKey(stockEvent.ProductId.ToString())
         );
         return Results.Accepted($"/jobs/{jobId}");
+    }
+);
+
+app.MapDelete(
+    "/jobs/{jobId:guid}",
+    async (Guid jobId, [FromServices] IAtomizerClient atomizerClient) =>
+    {
+        var dequeued = await atomizerClient.DequeueAsync(jobId);
+        return dequeued
+            ? Results.NoContent()
+            : Results.Conflict(new { message = "The job was not pending or was not found." });
+    }
+);
+
+app.MapDelete(
+    "/recurring/{name}",
+    async (string name, [FromServices] IAtomizerClient atomizerClient) =>
+    {
+        await atomizerClient.DeleteRecurringAsync(name);
+        return Results.NoContent();
     }
 );
 

--- a/samples/Atomizer.Example/Atomizer.Example.http
+++ b/samples/Atomizer.Example/Atomizer.Example.http
@@ -1,6 +1,42 @@
 @Atomizer.Example_HostAddress = http://localhost:5191
+@PendingJobId = 00000000-0000-0000-0000-000000000000
 
-GET {{Atomizer.Example_HostAddress}}/weatherforecast/
+POST {{Atomizer.Example_HostAddress}}/log
 Accept: application/json
 
 ###
+
+POST {{Atomizer.Example_HostAddress}}/execute/log
+Accept: application/json
+
+###
+
+POST {{Atomizer.Example_HostAddress}}/exception
+Accept: application/json
+
+###
+
+POST {{Atomizer.Example_HostAddress}}/schedule?runInSeconds=60
+Accept: application/json
+
+###
+
+POST {{Atomizer.Example_HostAddress}}/log-to-queue?queue=priority-queue
+Accept: application/json
+
+###
+
+POST {{Atomizer.Example_HostAddress}}/long-running?durationInSeconds=10
+Accept: application/json
+
+###
+
+# Replace @PendingJobId with a job id returned by /schedule before the job is picked up.
+DELETE {{Atomizer.Example_HostAddress}}/jobs/{{PendingJobId}}
+Accept: application/json
+
+###
+
+# Idempotent: returns no content even when the recurring schedule is already gone.
+DELETE {{Atomizer.Example_HostAddress}}/recurring/LoggerJob
+Accept: application/json

--- a/samples/Atomizer.Example/Program.cs
+++ b/samples/Atomizer.Example/Program.cs
@@ -57,16 +57,18 @@ if (app.Environment.IsDevelopment())
 }
 
 var atomizer = app.Services.GetRequiredService<IAtomizerClient>();
+const string recurringLoggerJob = "LoggerJob";
+const string recurringLoggerCatchUpJob = "LoggerJobCatchUp";
 
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
-    "LoggerJob",
+    recurringLoggerJob,
     Schedule.Every(2).Minutes()
 );
 
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Recurring job started", LogLevel.Information),
-    "LoggerJobCatchUp",
+    recurringLoggerCatchUpJob,
     Schedule.Cron("0/5 * * * * *"), // Every 5 seconds,
     options => options.MisfirePolicy = MisfirePolicy.CatchUp
 );
@@ -75,7 +77,19 @@ app.MapPost(
     "/log",
     async ([FromServices] IAtomizerClient atomizerClient) =>
     {
-        await atomizerClient.EnqueueAsync(new LoggerJobPayload("Hello, Atomizer!", LogLevel.Information));
+        var jobId = await atomizerClient.EnqueueAsync(new LoggerJobPayload("Hello, Atomizer!", LogLevel.Information));
+        return Results.Accepted($"/jobs/{jobId}", new { jobId });
+    }
+);
+
+app.MapPost(
+    "/execute/log",
+    async ([FromServices] IAtomizerClient atomizerClient) =>
+    {
+        var jobId = await atomizerClient.ExecuteAsync(
+            new LoggerJobPayload("Executed immediately from the sample API", LogLevel.Information)
+        );
+        return Results.Ok(new { jobId });
     }
 );
 
@@ -83,7 +97,8 @@ app.MapPost(
     "/exception",
     async ([FromServices] IAtomizerClient atomizerClient) =>
     {
-        await atomizerClient.EnqueueAsync(new ExceptionJobPayload("This job will always fail!"));
+        var jobId = await atomizerClient.EnqueueAsync(new ExceptionJobPayload("This job will always fail!"));
+        return Results.Accepted($"/jobs/{jobId}", new { jobId });
     }
 );
 
@@ -91,7 +106,8 @@ app.MapPost(
     "/empty",
     async ([FromServices] IAtomizerClient atomizerClient) =>
     {
-        await atomizerClient.EnqueueAsync(new EmptyPayload());
+        var jobId = await atomizerClient.EnqueueAsync(new EmptyPayload());
+        return Results.Accepted($"/jobs/{jobId}", new { jobId });
     }
 );
 
@@ -100,10 +116,11 @@ app.MapPost(
     async ([FromQuery] int runInSeconds, [FromServices] IAtomizerClient atomizerClient) =>
     {
         var runAt = DateTimeOffset.UtcNow.AddSeconds(runInSeconds);
-        await atomizerClient.ScheduleAsync(
+        var jobId = await atomizerClient.ScheduleAsync(
             new LoggerJobPayload("This job is scheduled to run in 1 minute.", LogLevel.Information),
             runAt
         );
+        return Results.Accepted($"/jobs/{jobId}", new { jobId });
     }
 );
 
@@ -111,10 +128,11 @@ app.MapPost(
     "/log-to-queue",
     async (string queue, [FromServices] IAtomizerClient atomizerClient) =>
     {
-        await atomizerClient.EnqueueAsync(
+        var jobId = await atomizerClient.EnqueueAsync(
             new LoggerJobPayload($"Logging to {queue} queue!", LogLevel.Information),
             options => options.Queue = queue
         );
+        return Results.Accepted($"/jobs/{jobId}", new { jobId });
     }
 );
 
@@ -122,7 +140,28 @@ app.MapPost(
     "/long-running",
     async ([FromQuery] int durationInSeconds, [FromServices] IAtomizerClient atomizerClient) =>
     {
-        await atomizerClient.EnqueueAsync(new LongRunningJobPayload(durationInSeconds));
+        var jobId = await atomizerClient.EnqueueAsync(new LongRunningJobPayload(durationInSeconds));
+        return Results.Accepted($"/jobs/{jobId}", new { jobId });
+    }
+);
+
+app.MapDelete(
+    "/jobs/{jobId:guid}",
+    async (Guid jobId, [FromServices] IAtomizerClient atomizerClient) =>
+    {
+        var dequeued = await atomizerClient.DequeueAsync(jobId);
+        return dequeued
+            ? Results.NoContent()
+            : Results.Conflict(new { message = "The job was not pending or was not found." });
+    }
+);
+
+app.MapDelete(
+    "/recurring/{name}",
+    async (string name, [FromServices] IAtomizerClient atomizerClient) =>
+    {
+        await atomizerClient.DeleteRecurringAsync(name);
+        return Results.NoContent();
     }
 );
 

--- a/samples/Atomizer.Redis.Example/Atomizer.Redis.Example.http
+++ b/samples/Atomizer.Redis.Example/Atomizer.Redis.Example.http
@@ -1,6 +1,12 @@
 @Atomizer.Redis.Example_HostAddress = http://localhost:5053
+@PendingJobId = 00000000-0000-0000-0000-000000000000
 
 POST {{Atomizer.Redis.Example_HostAddress}}/log
+Accept: application/json
+
+###
+
+POST {{Atomizer.Redis.Example_HostAddress}}/execute/log
 Accept: application/json
 
 ###
@@ -27,3 +33,15 @@ Content-Type: application/json
   "accountId": "account-123",
   "eventName": "StatementGenerated"
 }
+
+###
+
+# Replace @PendingJobId with a job id returned by /schedule before the job is picked up.
+DELETE {{Atomizer.Redis.Example_HostAddress}}/jobs/{{PendingJobId}}
+Accept: application/json
+
+###
+
+# Idempotent: returns no content even when the recurring schedule is already gone.
+DELETE {{Atomizer.Redis.Example_HostAddress}}/recurring/RedisRecurringLogger
+Accept: application/json

--- a/samples/Atomizer.Redis.Example/Program.cs
+++ b/samples/Atomizer.Redis.Example/Program.cs
@@ -63,10 +63,11 @@ if (app.Environment.IsDevelopment())
 }
 
 var atomizer = app.Services.GetRequiredService<IAtomizerClient>();
+const string redisRecurringLoggerJob = "RedisRecurringLogger";
 
 await atomizer.ScheduleRecurringAsync(
     new LoggerJobPayload("Redis recurring job started", LogLevel.Information),
-    "RedisRecurringLogger",
+    redisRecurringLoggerJob,
     Schedule.Cron("0/30 * * * * *")
 );
 
@@ -78,6 +79,17 @@ app.MapPost(
             new LoggerJobPayload("Hello from the Redis storage sample", LogLevel.Information)
         );
         return Results.Accepted($"/jobs/{jobId}", new { jobId });
+    }
+);
+
+app.MapPost(
+    "/execute/log",
+    async ([FromServices] IAtomizerClient atomizerClient) =>
+    {
+        var jobId = await atomizerClient.ExecuteAsync(
+            new LoggerJobPayload("Executed immediately from the Redis sample API", LogLevel.Information)
+        );
+        return Results.Ok(new { jobId });
     }
 );
 
@@ -130,6 +142,26 @@ app.MapPost(
             }
         );
         return Results.Accepted($"/jobs/{jobId}", new { jobId });
+    }
+);
+
+app.MapDelete(
+    "/jobs/{jobId:guid}",
+    async (Guid jobId, [FromServices] IAtomizerClient atomizerClient) =>
+    {
+        var dequeued = await atomizerClient.DequeueAsync(jobId);
+        return dequeued
+            ? Results.NoContent()
+            : Results.Conflict(new { message = "The job was not pending or was not found." });
+    }
+);
+
+app.MapDelete(
+    "/recurring/{name}",
+    async (string name, [FromServices] IAtomizerClient atomizerClient) =>
+    {
+        await atomizerClient.DeleteRecurringAsync(name);
+        return Results.NoContent();
     }
 );
 

--- a/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
+++ b/src/Atomizer.EntityFrameworkCore/Storage/EntityFrameworkCoreStorage.cs
@@ -278,6 +278,21 @@ internal sealed class EntityFrameworkCoreStorage<TDbContext> : IAtomizerStorage
         throw UnsupportedProviderException(_providerCache.ProviderName);
     }
 
+    public async Task<bool> DeleteScheduleAsync(JobKey jobKey, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var entity = await ScheduleEntities.FirstOrDefaultAsync(s => s.JobKey == jobKey.ToString(), cancellationToken);
+        if (entity is null)
+        {
+            return false;
+        }
+
+        ScheduleEntities.Remove(entity);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+
     public async Task UpdateSchedulesAsync(IEnumerable<AtomizerSchedule> schedules, CancellationToken cancellationToken)
     {
         try

--- a/src/Atomizer.Redis/Storage/RedisStorage.cs
+++ b/src/Atomizer.Redis/Storage/RedisStorage.cs
@@ -255,6 +255,26 @@ internal sealed class RedisStorage : IAtomizerStorage, IDisposable
         }
     }
 
+    public async Task<bool> DeleteScheduleAsync(JobKey jobKey, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var lockValue = await AcquireLockAsync(_keys.SchedulesLock, wait: true, cancellationToken);
+        try
+        {
+            var existing = await ReadScheduleAsync(jobKey.Key, cancellationToken);
+            if (existing is null)
+                return false;
+
+            await DeleteScheduleRecordAsync(jobKey);
+            return true;
+        }
+        finally
+        {
+            await ReleaseLockAsync(_keys.SchedulesLock, lockValue);
+        }
+    }
+
     public async Task UpdateSchedulesAsync(IEnumerable<AtomizerSchedule> schedules, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -601,6 +621,12 @@ internal sealed class RedisStorage : IAtomizerStorage, IDisposable
             RedisRecordSerializer.Serialize(RedisScheduleRecord.FromSchedule(schedule))
         );
         await Database.SortedSetAddAsync(_keys.SchedulesByNextRun, schedule.JobKey.Key, Score(schedule.NextRunAt));
+    }
+
+    private async Task DeleteScheduleRecordAsync(JobKey jobKey)
+    {
+        await Database.KeyDeleteAsync(_keys.Schedule(jobKey.Key));
+        await Database.SortedSetRemoveAsync(_keys.SchedulesByNextRun, jobKey.Key);
     }
 
     private async Task<AtomizerSchedule?> ReadScheduleAsync(string jobKey, CancellationToken cancellationToken)

--- a/src/Atomizer/Abstractions/IAtomizerClient.cs
+++ b/src/Atomizer/Abstractions/IAtomizerClient.cs
@@ -53,6 +53,43 @@ public interface IAtomizerClient
         Action<RecurringOptions>? configure = null,
         CancellationToken cancellation = default
     );
+
+    /// <summary>
+    /// Dequeues a pending job so it will not be processed.
+    /// </summary>
+    /// <param name="jobId">The unique identifier of the job to dequeue.</param>
+    /// <param name="cancellation">Cancellation token to cancel the operation.</param>
+    /// <returns>
+    /// <see langword="true"/> when a pending job was dequeued; otherwise <see langword="false"/> when the job
+    /// does not exist or is no longer pending.
+    /// </returns>
+    Task<bool> DequeueAsync(Guid jobId, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Idempotently deletes a recurring schedule.
+    /// </summary>
+    /// <param name="name">The unique key identifying the recurring schedule.</param>
+    /// <param name="cancellation">Cancellation token to cancel the operation.</param>
+    /// <returns><see langword="true"/> when a schedule was deleted; otherwise <see langword="false"/>.</returns>
+    Task<bool> DeleteRecurringAsync(JobKey name, CancellationToken cancellation = default);
+
+    /// <summary>
+    /// Executes a job immediately in the current process while recording it in Atomizer as completed or failed.
+    /// </summary>
+    /// <typeparam name="TPayload">The type of the payload to execute.</typeparam>
+    /// <param name="payload">The payload to execute.</param>
+    /// <param name="configure">Optional delegate to configure execution options such as queue, idempotency key, and retry strategy.</param>
+    /// <param name="cancellation">Cancellation token to cancel the operation.</param>
+    /// <returns>The unique identifier of the executed job.</returns>
+    /// <remarks>
+    /// If the job handler throws, Atomizer records the job as failed and then rethrows the original exception.
+    /// Direct execution does not schedule background retries.
+    /// </remarks>
+    Task<Guid> ExecuteAsync<TPayload>(
+        TPayload payload,
+        Action<EnqueueOptions>? configure = null,
+        CancellationToken cancellation = default
+    );
 }
 
 /// <summary>

--- a/src/Atomizer/Abstractions/IAtomizerStorage.cs
+++ b/src/Atomizer/Abstractions/IAtomizerStorage.cs
@@ -71,6 +71,14 @@ public interface IAtomizerStorage
     Task<Guid> UpsertScheduleAsync(AtomizerSchedule schedule, CancellationToken cancellationToken);
 
     /// <summary>
+    /// Deletes the recurring schedule identified by the supplied job key when it exists.
+    /// </summary>
+    /// <param name="jobKey">The unique recurring schedule key to delete.</param>
+    /// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
+    /// <returns><see langword="true"/> when a schedule was deleted; otherwise <see langword="false"/>.</returns>
+    Task<bool> DeleteScheduleAsync(JobKey jobKey, CancellationToken cancellationToken);
+
+    /// <summary>
     /// Updates a range of existing Atomizer schedules in the storage.
     /// </summary>
     /// <param name="schedules">The collection of Atomizer schedules to be updated.</param>

--- a/src/Atomizer/Configuration/ServiceCollectionExtensions.cs
+++ b/src/Atomizer/Configuration/ServiceCollectionExtensions.cs
@@ -43,6 +43,7 @@ public static class ServiceCollectionExtensions
         services.Add(options.Handlers);
         services.AddSingleton<IAtomizerClient, AtomizerClient>();
         services.AddSingleton<IAtomizerClock, AtomizerClock>();
+        services.TryAddSingleton<AtomizerRuntimeIdentity>();
         services.AddSingleton<IAtomizerJobTypeResolver, DefaultJobTypeResolver>();
         services.AddSingleton<IAtomizerJobDispatcher, DefaultJobDispatcher>();
         services.AddSingleton<IAtomizerJobSerializer, DefaultJobSerializer>();
@@ -76,7 +77,7 @@ public static class ServiceCollectionExtensions
         options.Validate();
 
         services.AddSingleton(options);
-        services.AddSingleton<AtomizerRuntimeIdentity>();
+        services.TryAddSingleton<AtomizerRuntimeIdentity>();
         services.AddHostedService<AtomizerHeartbeatRecoveryService>();
         services.AddHostedService<AtomizerQueueService>();
         if (options.JobRetention is not null)

--- a/src/Atomizer/Core/AtomizerClient.cs
+++ b/src/Atomizer/Core/AtomizerClient.cs
@@ -9,6 +9,7 @@ namespace Atomizer.Core;
 /// </summary>
 public sealed class AtomizerClient : IAtomizerClient
 {
+    private static readonly TimeSpan DirectExecutionHeartbeatInterval = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan DirectExecutionVisibilityTimeout = TimeSpan.FromDays(1);
 
     private readonly IAtomizerServiceScopeFactory _serviceScopeFactory;
@@ -178,10 +179,14 @@ public sealed class AtomizerClient : IAtomizerClient
         );
 
         job.Lease(CreateDirectLeaseToken(options.Queue), now, DirectExecutionVisibilityTimeout);
-        job.Attempt();
 
         using var scope = _serviceScopeFactory.CreateScope();
         var storage = scope.Storage;
+        await storage.UpsertHeartbeatAsync(
+            new AtomizerActiveServer { InstanceId = _identity.InstanceId, LastHeartbeatAt = now },
+            cancellation
+        );
+
         var jobId = await storage.InsertAsync(job, cancellation);
         if (jobId != job.Id)
         {
@@ -193,12 +198,15 @@ public sealed class AtomizerClient : IAtomizerClient
             return jobId;
         }
 
+        using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
+        var heartbeatTask = RunDirectExecutionHeartbeatAsync(heartbeatCts.Token);
         try
         {
+            job.Attempt();
             await _dispatcher.DispatchAsync(job, cancellation);
             job.MarkAsCompleted(_clock.UtcNow);
 
-            await storage.UpdateJobsAsync(new[] { job }, cancellation);
+            await storage.UpdateJobsAsync(new[] { job }, CancellationToken.None);
 
             _logger.LogInformation(
                 "Direct execution of job {JobId} with payload type {PayloadType} completed",
@@ -207,6 +215,22 @@ public sealed class AtomizerClient : IAtomizerClient
             );
 
             return job.Id;
+        }
+        catch (OperationCanceledException ex) when (cancellation.IsCancellationRequested)
+        {
+            job.Attempts -= 1;
+            job.Release(_clock.UtcNow);
+
+            await storage.UpdateJobsAsync(new[] { job }, CancellationToken.None);
+
+            _logger.LogWarning(
+                ex,
+                "Direct execution of job {JobId} with payload type {PayloadType} was cancelled",
+                job.Id,
+                job.PayloadType?.FullName
+            );
+
+            throw;
         }
         catch (Exception ex)
         {
@@ -224,6 +248,11 @@ public sealed class AtomizerClient : IAtomizerClient
             );
 
             throw;
+        }
+        finally
+        {
+            heartbeatCts.Cancel();
+            await StopDirectExecutionHeartbeatAsync(heartbeatTask);
         }
     }
 
@@ -263,4 +292,46 @@ public sealed class AtomizerClient : IAtomizerClient
 
     private LeaseToken CreateDirectLeaseToken(QueueKey queue) =>
         new LeaseToken($"{_identity.InstanceId}{LeaseToken.Delimiter}{queue}{LeaseToken.Delimiter}{Guid.NewGuid():N}");
+
+    private async Task RunDirectExecutionHeartbeatAsync(CancellationToken cancellation)
+    {
+        while (!cancellation.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(DirectExecutionHeartbeatInterval, cancellation);
+                await UpsertDirectExecutionHeartbeatAsync(_clock.UtcNow, cancellation);
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+                return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to refresh Atomizer heartbeat during direct execution for instance {InstanceId}",
+                    _identity.InstanceId
+                );
+            }
+        }
+    }
+
+    private async Task UpsertDirectExecutionHeartbeatAsync(DateTimeOffset now, CancellationToken cancellation)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        await scope.Storage.UpsertHeartbeatAsync(
+            new AtomizerActiveServer { InstanceId = _identity.InstanceId, LastHeartbeatAt = now },
+            cancellation
+        );
+    }
+
+    private async Task StopDirectExecutionHeartbeatAsync(Task heartbeatTask)
+    {
+        try
+        {
+            await heartbeatTask;
+        }
+        catch (OperationCanceledException) { }
+    }
 }

--- a/src/Atomizer/Core/AtomizerClient.cs
+++ b/src/Atomizer/Core/AtomizerClient.cs
@@ -15,24 +15,9 @@ public sealed class AtomizerClient : IAtomizerClient
     private readonly IAtomizerServiceScopeFactory _serviceScopeFactory;
     private readonly IAtomizerJobSerializer _jobSerializer;
     private readonly IAtomizerClock _clock;
-    private readonly IAtomizerJobDispatcher? _dispatcher;
+    private readonly IAtomizerJobDispatcher _dispatcher;
     private readonly AtomizerRuntimeIdentity _identity;
     private readonly ILogger<AtomizerClient> _logger;
-
-    /// <summary>
-    /// Initializes a new <see cref="AtomizerClient"/> with the required dependencies.
-    /// </summary>
-    /// <param name="serviceScopeFactory">Factory used to create storage scopes.</param>
-    /// <param name="jobSerializer">Serializer used to serialize job payloads.</param>
-    /// <param name="clock">Clock abstraction for obtaining the current UTC time.</param>
-    /// <param name="logger">Logger for diagnostic output.</param>
-    public AtomizerClient(
-        IAtomizerServiceScopeFactory serviceScopeFactory,
-        IAtomizerJobSerializer jobSerializer,
-        IAtomizerClock clock,
-        ILogger<AtomizerClient> logger
-    )
-        : this(serviceScopeFactory, jobSerializer, clock, null, new AtomizerRuntimeIdentity(), logger) { }
 
     /// <summary>
     /// Initializes a new <see cref="AtomizerClient"/> with the required dependencies.
@@ -47,7 +32,7 @@ public sealed class AtomizerClient : IAtomizerClient
         IAtomizerServiceScopeFactory serviceScopeFactory,
         IAtomizerJobSerializer jobSerializer,
         IAtomizerClock clock,
-        IAtomizerJobDispatcher? dispatcher,
+        IAtomizerJobDispatcher dispatcher,
         AtomizerRuntimeIdentity identity,
         ILogger<AtomizerClient> logger
     )
@@ -55,7 +40,7 @@ public sealed class AtomizerClient : IAtomizerClient
         _serviceScopeFactory = serviceScopeFactory;
         _jobSerializer = jobSerializer;
         _clock = clock;
-        _dispatcher = dispatcher;
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _identity = identity;
         _logger = logger;
     }
@@ -156,13 +141,6 @@ public sealed class AtomizerClient : IAtomizerClient
         CancellationToken cancellation = default
     )
     {
-        if (_dispatcher is null)
-        {
-            throw new InvalidOperationException(
-                "Direct job execution requires IAtomizerJobDispatcher. Use AddAtomizer to construct IAtomizerClient."
-            );
-        }
-
         var options = new EnqueueOptions();
         configure?.Invoke(options);
 

--- a/src/Atomizer/Core/AtomizerClient.cs
+++ b/src/Atomizer/Core/AtomizerClient.cs
@@ -9,9 +9,13 @@ namespace Atomizer.Core;
 /// </summary>
 public sealed class AtomizerClient : IAtomizerClient
 {
+    private static readonly TimeSpan DirectExecutionVisibilityTimeout = TimeSpan.FromDays(1);
+
     private readonly IAtomizerServiceScopeFactory _serviceScopeFactory;
     private readonly IAtomizerJobSerializer _jobSerializer;
     private readonly IAtomizerClock _clock;
+    private readonly IAtomizerJobDispatcher? _dispatcher;
+    private readonly AtomizerRuntimeIdentity _identity;
     private readonly ILogger<AtomizerClient> _logger;
 
     /// <summary>
@@ -27,10 +31,31 @@ public sealed class AtomizerClient : IAtomizerClient
         IAtomizerClock clock,
         ILogger<AtomizerClient> logger
     )
+        : this(serviceScopeFactory, jobSerializer, clock, null, new AtomizerRuntimeIdentity(), logger) { }
+
+    /// <summary>
+    /// Initializes a new <see cref="AtomizerClient"/> with the required dependencies.
+    /// </summary>
+    /// <param name="serviceScopeFactory">Factory used to create storage scopes.</param>
+    /// <param name="jobSerializer">Serializer used to serialize job payloads.</param>
+    /// <param name="clock">Clock abstraction for obtaining the current UTC time.</param>
+    /// <param name="dispatcher">Dispatcher used to execute jobs directly.</param>
+    /// <param name="identity">Runtime identity used to tag direct execution attempts.</param>
+    /// <param name="logger">Logger for diagnostic output.</param>
+    public AtomizerClient(
+        IAtomizerServiceScopeFactory serviceScopeFactory,
+        IAtomizerJobSerializer jobSerializer,
+        IAtomizerClock clock,
+        IAtomizerJobDispatcher? dispatcher,
+        AtomizerRuntimeIdentity identity,
+        ILogger<AtomizerClient> logger
+    )
     {
         _serviceScopeFactory = serviceScopeFactory;
         _jobSerializer = jobSerializer;
         _clock = clock;
+        _dispatcher = dispatcher;
+        _identity = identity;
         _logger = logger;
     }
 
@@ -92,6 +117,116 @@ public sealed class AtomizerClient : IAtomizerClient
         return await scope.Storage.UpsertScheduleAsync(atomizerSchedule, cancellation);
     }
 
+    /// <inheritdoc/>
+    public async Task<bool> DequeueAsync(Guid jobId, CancellationToken cancellation = default)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var storage = scope.Storage;
+        var job = await storage.GetJobByIdAsync(jobId, cancellation);
+        if (job is null || job.Status != AtomizerJobStatus.Pending)
+        {
+            return false;
+        }
+
+        try
+        {
+            job.Cancel(_clock.UtcNow);
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+
+        await storage.UpdateJobsAsync(new[] { job }, cancellation);
+        return true;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> DeleteRecurringAsync(JobKey name, CancellationToken cancellation = default)
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        return await scope.Storage.DeleteScheduleAsync(name, cancellation);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Guid> ExecuteAsync<TPayload>(
+        TPayload payload,
+        Action<EnqueueOptions>? configure = null,
+        CancellationToken cancellation = default
+    )
+    {
+        if (_dispatcher is null)
+        {
+            throw new InvalidOperationException(
+                "Direct job execution requires IAtomizerJobDispatcher. Use AddAtomizer to construct IAtomizerClient."
+            );
+        }
+
+        var options = new EnqueueOptions();
+        configure?.Invoke(options);
+
+        var now = _clock.UtcNow;
+        var job = AtomizerJob.Create(
+            options.Queue,
+            typeof(TPayload),
+            _jobSerializer.Serialize(payload),
+            now,
+            now,
+            options.RetryStrategy,
+            options.IdempotencyKey,
+            partitionKey: options.PartitionKey
+        );
+
+        job.Lease(CreateDirectLeaseToken(options.Queue), now, DirectExecutionVisibilityTimeout);
+        job.Attempt();
+
+        using var scope = _serviceScopeFactory.CreateScope();
+        var storage = scope.Storage;
+        var jobId = await storage.InsertAsync(job, cancellation);
+        if (jobId != job.Id)
+        {
+            _logger.LogDebug(
+                "Direct execution skipped for existing idempotent job {JobId} with payload type {PayloadType}",
+                jobId,
+                job.PayloadType?.FullName
+            );
+            return jobId;
+        }
+
+        try
+        {
+            await _dispatcher.DispatchAsync(job, cancellation);
+            job.MarkAsCompleted(_clock.UtcNow);
+
+            await storage.UpdateJobsAsync(new[] { job }, cancellation);
+
+            _logger.LogInformation(
+                "Direct execution of job {JobId} with payload type {PayloadType} completed",
+                job.Id,
+                job.PayloadType?.FullName
+            );
+
+            return job.Id;
+        }
+        catch (Exception ex)
+        {
+            var failedAt = _clock.UtcNow;
+            job.Errors.Add(AtomizerJobError.Create(job.Id, failedAt, job.Attempts, ex, job.LeaseToken?.InstanceId));
+            job.MarkAsFailed(failedAt);
+
+            await storage.UpdateJobsAsync(new[] { job }, CancellationToken.None);
+
+            _logger.LogError(
+                ex,
+                "Direct execution of job {JobId} with payload type {PayloadType} failed",
+                job.Id,
+                job.PayloadType?.FullName
+            );
+
+            throw;
+        }
+    }
+
     private async Task<Guid> EnqueueInternalAsync<TPayload>(
         TPayload payload,
         DateTimeOffset when,
@@ -125,4 +260,7 @@ public sealed class AtomizerClient : IAtomizerClient
 
         return jobId;
     }
+
+    private LeaseToken CreateDirectLeaseToken(QueueKey queue) =>
+        new LeaseToken($"{_identity.InstanceId}{LeaseToken.Delimiter}{queue}{LeaseToken.Delimiter}{Guid.NewGuid():N}");
 }

--- a/src/Atomizer/Storage/InMemoryStorage.cs
+++ b/src/Atomizer/Storage/InMemoryStorage.cs
@@ -385,6 +385,29 @@ public sealed class InMemoryStorage : IAtomizerStorage
     }
 
     /// <inheritdoc/>
+    public async Task<bool> DeleteScheduleAsync(JobKey jobKey, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var scheduleLock = _semaphores.GetOrAdd(QueueKey.Scheduler, _ => new SemaphoreSlim(1, 1));
+        await scheduleLock.WaitAsync(cancellationToken);
+        try
+        {
+            var removed = _schedules.Remove(jobKey);
+            if (removed)
+            {
+                _logger.LogDebug("DeleteSchedule: deleted schedule for jobKey={JobKey}", jobKey);
+            }
+
+            return removed;
+        }
+        finally
+        {
+            scheduleLock.Release();
+        }
+    }
+
+    /// <inheritdoc/>
     public Task UpdateSchedulesAsync(IEnumerable<AtomizerSchedule> schedules, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreAtomizerClientIntegrationTests.cs
+++ b/tests/Atomizer.EntityFrameworkCore.Tests/Storage/EntityFrameworkCoreAtomizerClientIntegrationTests.cs
@@ -1,0 +1,172 @@
+using Atomizer.Abstractions;
+using Atomizer.EntityFrameworkCore.Tests.Fixtures;
+using Atomizer.EntityFrameworkCore.Tests.TestSetup;
+using Atomizer.EntityFrameworkCore.Tests.TestSetup.MySql;
+using Atomizer.EntityFrameworkCore.Tests.TestSetup.Postgres;
+using Atomizer.EntityFrameworkCore.Tests.TestSetup.SqlServer;
+using Atomizer.Tests.Utilities.TestJobs;
+using AwesomeAssertions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atomizer.EntityFrameworkCore.Tests.Storage;
+
+public abstract class EntityFrameworkCoreAtomizerClientIntegrationTests<TDbContext> : IAsyncLifetime
+    where TDbContext : TestDbContext
+{
+    private ServiceProvider? _provider;
+
+    protected abstract TDbContext CreateDbContext();
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_provider is not null)
+        {
+            await _provider.DisposeAsync();
+        }
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        await using var cleanupContext = CreateDbContext();
+        await StorageTestCleanup.ClearAsync(cleanupContext, cts.Token);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHandlerSucceeds_ShouldPersistCompletedJobAndRunHandler()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+
+        var jobId = await client.ExecuteAsync(
+            new ClientActionTestPayload("direct execution"),
+            cancellation: TestContext.Current.CancellationToken
+        );
+
+        var job = await GetJobAsync(provider, jobId);
+        job.Should().NotBeNull();
+        job!.Status.Should().Be(AtomizerJobStatus.Completed);
+        job.CompletedAt.Should().NotBeNull();
+        job.FailedAt.Should().BeNull();
+        job.Errors.Should().BeEmpty();
+        provider.GetRequiredService<ClientActionTestRecorder>().Messages.Should().ContainSingle("direct execution");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHandlerThrows_ShouldPersistFailedJobAndRethrow()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+        var recorder = provider.GetRequiredService<ClientActionTestRecorder>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.ExecuteAsync(
+                new FailingClientActionTestPayload("direct execution failed"),
+                cancellation: TestContext.Current.CancellationToken
+            )
+        );
+
+        exception.Message.Should().Be("direct execution failed");
+        recorder.FailedJobId.Should().NotBeNull();
+
+        var job = await GetJobAsync(provider, recorder.FailedJobId!.Value);
+        job.Should().NotBeNull();
+        job!.Status.Should().Be(AtomizerJobStatus.Failed);
+        job.CompletedAt.Should().BeNull();
+        job.FailedAt.Should().NotBeNull();
+        job.Errors.Should().ContainSingle();
+        job.Errors.Single().ExceptionType.Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task DequeueAsync_WhenScheduledJobIsPending_ShouldCancelPersistedJob()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+        var jobId = await client.ScheduleAsync(
+            new ClientActionTestPayload("cancel pending"),
+            DateTimeOffset.UtcNow.AddHours(1),
+            cancellation: TestContext.Current.CancellationToken
+        );
+
+        var dequeued = await client.DequeueAsync(jobId, TestContext.Current.CancellationToken);
+
+        dequeued.Should().BeTrue();
+        var job = await GetJobAsync(provider, jobId);
+        job.Should().NotBeNull();
+        job!.Status.Should().Be(AtomizerJobStatus.Cancelled);
+        job.VisibleAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteRecurringAsync_WhenScheduleExists_ShouldRemoveScheduleAndBeIdempotent()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+        var jobKey = new JobKey($"client-action-{Guid.NewGuid():N}");
+        await client.ScheduleRecurringAsync(
+            new ClientActionTestPayload("recurring"),
+            jobKey,
+            Schedule.Every(5).Minutes(),
+            cancellation: TestContext.Current.CancellationToken
+        );
+
+        var deleted = await client.DeleteRecurringAsync(jobKey, TestContext.Current.CancellationToken);
+        var deletedAgain = await client.DeleteRecurringAsync(jobKey, TestContext.Current.CancellationToken);
+
+        deleted.Should().BeTrue();
+        deletedAgain.Should().BeFalse();
+        var schedules = await GetSchedulesAsync(provider);
+        schedules.Should().NotContain(schedule => schedule.JobKey == jobKey);
+    }
+
+    private ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ClientActionTestRecorder>();
+        services.AddScoped(_ => CreateDbContext());
+        services.AddAtomizer(options =>
+        {
+            options.AddHandlersFrom<ClientActionTestJob>();
+            options.UseEntityFrameworkCoreStorage<TDbContext>();
+        });
+
+        _provider = services.BuildServiceProvider(validateScopes: true);
+        return _provider;
+    }
+
+    private static async Task<AtomizerJob?> GetJobAsync(IServiceProvider provider, Guid jobId)
+    {
+        using var scope = provider.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IAtomizerStorage>();
+        return await storage.GetJobByIdAsync(jobId, TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<IReadOnlyList<AtomizerSchedule>> GetSchedulesAsync(IServiceProvider provider)
+    {
+        using var scope = provider.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IAtomizerStorage>();
+        return await storage.GetSchedulesAsync(TestContext.Current.CancellationToken);
+    }
+}
+
+[Collection(nameof(MySqlDatabaseFixture))]
+public sealed class MySqlAtomizerClientIntegrationTests(MySqlDatabaseFixture fixture)
+    : EntityFrameworkCoreAtomizerClientIntegrationTests<MySqlDbContext>
+{
+    protected override MySqlDbContext CreateDbContext() => fixture.CreateNewDbContext();
+}
+
+[Collection(nameof(PostgreSqlDatabaseFixture))]
+public sealed class PostgresAtomizerClientIntegrationTests(PostgreSqlDatabaseFixture fixture)
+    : EntityFrameworkCoreAtomizerClientIntegrationTests<PostgresDbContext>
+{
+    protected override PostgresDbContext CreateDbContext() => fixture.CreateNewDbContext();
+}
+
+[Collection(nameof(SqlServerDatabaseFixture))]
+public sealed class SqlServerAtomizerClientIntegrationTests(SqlServerDatabaseFixture fixture)
+    : EntityFrameworkCoreAtomizerClientIntegrationTests<SqlServerDbContext>
+{
+    protected override SqlServerDbContext CreateDbContext() => fixture.CreateNewDbContext();
+}

--- a/tests/Atomizer.Redis.Tests/Storage/RedisAtomizerClientIntegrationTests.cs
+++ b/tests/Atomizer.Redis.Tests/Storage/RedisAtomizerClientIntegrationTests.cs
@@ -1,0 +1,149 @@
+using Atomizer.Abstractions;
+using Atomizer.Tests.Utilities.TestJobs;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atomizer.Redis.Tests.Storage;
+
+[Collection(nameof(RedisStorageFixture))]
+public sealed class RedisAtomizerClientIntegrationTests : IAsyncLifetime
+{
+    private readonly RedisStorageFixture _fixture;
+    private ServiceProvider? _provider;
+
+    public RedisAtomizerClientIntegrationTests(RedisStorageFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_provider is not null)
+        {
+            await _provider.DisposeAsync();
+        }
+
+        await _fixture.FlushAsync();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHandlerSucceeds_ShouldPersistCompletedJobAndRunHandler()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+
+        var jobId = await client.ExecuteAsync(
+            new ClientActionTestPayload("direct execution"),
+            cancellation: TestContext.Current.CancellationToken
+        );
+
+        var job = await GetJobAsync(provider, jobId);
+        job.Should().NotBeNull();
+        job!.Status.Should().Be(AtomizerJobStatus.Completed);
+        job.CompletedAt.Should().NotBeNull();
+        job.FailedAt.Should().BeNull();
+        job.Errors.Should().BeEmpty();
+        provider.GetRequiredService<ClientActionTestRecorder>().Messages.Should().ContainSingle("direct execution");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHandlerThrows_ShouldPersistFailedJobAndRethrow()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+        var recorder = provider.GetRequiredService<ClientActionTestRecorder>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.ExecuteAsync(
+                new FailingClientActionTestPayload("direct execution failed"),
+                cancellation: TestContext.Current.CancellationToken
+            )
+        );
+
+        exception.Message.Should().Be("direct execution failed");
+        recorder.FailedJobId.Should().NotBeNull();
+
+        var job = await GetJobAsync(provider, recorder.FailedJobId!.Value);
+        job.Should().NotBeNull();
+        job!.Status.Should().Be(AtomizerJobStatus.Failed);
+        job.CompletedAt.Should().BeNull();
+        job.FailedAt.Should().NotBeNull();
+        job.Errors.Should().ContainSingle();
+        job.Errors.Single().ExceptionType.Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task DequeueAsync_WhenScheduledJobIsPending_ShouldCancelPersistedJob()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+        var jobId = await client.ScheduleAsync(
+            new ClientActionTestPayload("cancel pending"),
+            DateTimeOffset.UtcNow.AddHours(1),
+            cancellation: TestContext.Current.CancellationToken
+        );
+
+        var dequeued = await client.DequeueAsync(jobId, TestContext.Current.CancellationToken);
+
+        dequeued.Should().BeTrue();
+        var job = await GetJobAsync(provider, jobId);
+        job.Should().NotBeNull();
+        job!.Status.Should().Be(AtomizerJobStatus.Cancelled);
+        job.VisibleAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteRecurringAsync_WhenScheduleExists_ShouldRemoveScheduleAndBeIdempotent()
+    {
+        var provider = CreateProvider();
+        var client = provider.GetRequiredService<IAtomizerClient>();
+        var jobKey = new JobKey($"client-action-{Guid.NewGuid():N}");
+        await client.ScheduleRecurringAsync(
+            new ClientActionTestPayload("recurring"),
+            jobKey,
+            Schedule.Every(5).Minutes(),
+            cancellation: TestContext.Current.CancellationToken
+        );
+
+        var deleted = await client.DeleteRecurringAsync(jobKey, TestContext.Current.CancellationToken);
+        var deletedAgain = await client.DeleteRecurringAsync(jobKey, TestContext.Current.CancellationToken);
+
+        deleted.Should().BeTrue();
+        deletedAgain.Should().BeFalse();
+        var schedules = await GetSchedulesAsync(provider);
+        schedules.Should().NotContain(schedule => schedule.JobKey == jobKey);
+    }
+
+    private ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<ClientActionTestRecorder>();
+        services.AddAtomizer(options =>
+        {
+            options.AddHandlersFrom<ClientActionTestJob>();
+            options.UseRedisStorage(
+                _fixture.Connection,
+                storage => storage.KeyPrefix = $"client-actions:{Guid.NewGuid():N}"
+            );
+        });
+
+        _provider = services.BuildServiceProvider(validateScopes: true);
+        return _provider;
+    }
+
+    private static async Task<AtomizerJob?> GetJobAsync(IServiceProvider provider, Guid jobId)
+    {
+        using var scope = provider.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IAtomizerStorage>();
+        return await storage.GetJobByIdAsync(jobId, TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<IReadOnlyList<AtomizerSchedule>> GetSchedulesAsync(IServiceProvider provider)
+    {
+        using var scope = provider.CreateScope();
+        var storage = scope.ServiceProvider.GetRequiredService<IAtomizerStorage>();
+        return await storage.GetSchedulesAsync(TestContext.Current.CancellationToken);
+    }
+}

--- a/tests/Atomizer.Tests.Utilities/StorageContract/AtomizerStorageContractTests.cs
+++ b/tests/Atomizer.Tests.Utilities/StorageContract/AtomizerStorageContractTests.cs
@@ -540,6 +540,33 @@ public abstract class AtomizerStorageContractTests : IAsyncLifetime
         (await _sut.GetJobByIdAsync(oldPending.Id, CancellationToken.None)).Should().NotBeNull();
     }
 
+    /// <summary>
+    /// Schedule deletion removes an existing recurring schedule.
+    /// </summary>
+    [Fact]
+    public async Task DeleteScheduleAsync_WhenScheduleExists_ShouldRemoveScheduleAndReturnTrue()
+    {
+        var schedule = CreateSchedule("nightly-report");
+        await _sut.UpsertScheduleAsync(schedule, CancellationToken.None);
+
+        var deleted = await _sut.DeleteScheduleAsync(schedule.JobKey, CancellationToken.None);
+
+        deleted.Should().BeTrue();
+        var schedules = await _sut.GetSchedulesAsync(CancellationToken.None);
+        schedules.Should().NotContain(s => s.JobKey == schedule.JobKey);
+    }
+
+    /// <summary>
+    /// Schedule deletion is idempotent when the recurring schedule does not exist.
+    /// </summary>
+    [Fact]
+    public async Task DeleteScheduleAsync_WhenScheduleDoesNotExist_ShouldReturnFalse()
+    {
+        var deleted = await _sut.DeleteScheduleAsync(new JobKey("missing-schedule"), CancellationToken.None);
+
+        deleted.Should().BeFalse();
+    }
+
     // ------------------------------------------------------------------
     // Helper
     // ------------------------------------------------------------------
@@ -561,4 +588,15 @@ public abstract class AtomizerStorageContractTests : IAsyncLifetime
             partitionKey: partitionKey
         );
     }
+
+    private AtomizerSchedule CreateSchedule(string jobKey) =>
+        AtomizerSchedule.Create(
+            new JobKey(jobKey),
+            QueueKey.Default,
+            typeof(WriteLineJob),
+            "{}",
+            Schedule.Default,
+            TimeZoneInfo.Utc,
+            _now
+        );
 }

--- a/tests/Atomizer.Tests.Utilities/TestJobs/ClientActionTestJobs.cs
+++ b/tests/Atomizer.Tests.Utilities/TestJobs/ClientActionTestJobs.cs
@@ -1,0 +1,59 @@
+namespace Atomizer.Tests.Utilities.TestJobs;
+
+public sealed record ClientActionTestPayload(string Message);
+
+public sealed record FailingClientActionTestPayload(string Message);
+
+public sealed class ClientActionTestRecorder
+{
+    private readonly object _sync = new object();
+    private readonly List<string> _messages = new List<string>();
+
+    public Guid? FailedJobId { get; private set; }
+
+    public IReadOnlyList<string> Messages
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _messages.ToArray();
+            }
+        }
+    }
+
+    public void RecordMessage(string message)
+    {
+        lock (_sync)
+        {
+            _messages.Add(message);
+        }
+    }
+
+    public void RecordFailedJob(Guid jobId)
+    {
+        lock (_sync)
+        {
+            FailedJobId = jobId;
+        }
+    }
+}
+
+public sealed class ClientActionTestJob(ClientActionTestRecorder recorder) : IAtomizerJob<ClientActionTestPayload>
+{
+    public Task HandleAsync(ClientActionTestPayload payload, JobContext context)
+    {
+        recorder.RecordMessage(payload.Message);
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class FailingClientActionTestJob(ClientActionTestRecorder recorder)
+    : IAtomizerJob<FailingClientActionTestPayload>
+{
+    public Task HandleAsync(FailingClientActionTestPayload payload, JobContext context)
+    {
+        recorder.RecordFailedJob(context.Job.Id);
+        throw new InvalidOperationException(payload.Message);
+    }
+}

--- a/tests/Atomizer.Tests/Core/AtomizerClientTests.cs
+++ b/tests/Atomizer.Tests/Core/AtomizerClientTests.cs
@@ -20,6 +20,9 @@ public class AtomizerClientTests
         _clock.UtcNow.Returns(_now);
         _serviceScope.Storage.Returns(_storage);
         _serviceScopeFactory.CreateScope().Returns(_serviceScope);
+        _storage
+            .UpsertHeartbeatAsync(Arg.Any<AtomizerActiveServer>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
     }
 
     [Fact]
@@ -96,13 +99,21 @@ public class AtomizerClientTests
         var queue = new QueueKey("critical");
         AtomizerJob? finalJob = null;
         AtomizerJobStatus? statusAtInsert = null;
+        int? attemptsAtInsert = null;
         AtomizerJobStatus? statusAtDispatch = null;
         _jobSerializer.Serialize(payload).Returns("{\"Message\":\"send\"}");
         _dispatcher
             .DispatchAsync(Arg.Do<AtomizerJob>(job => statusAtDispatch = job.Status), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
         _storage
-            .InsertAsync(Arg.Do<AtomizerJob>(job => statusAtInsert = job.Status), Arg.Any<CancellationToken>())
+            .InsertAsync(
+                Arg.Do<AtomizerJob>(job =>
+                {
+                    statusAtInsert = job.Status;
+                    attemptsAtInsert = job.Attempts;
+                }),
+                Arg.Any<CancellationToken>()
+            )
             .Returns(call => ((AtomizerJob)call[0]!).Id);
         _storage
             .UpdateJobsAsync(
@@ -121,6 +132,7 @@ public class AtomizerClientTests
         finalJob.Should().NotBeNull();
         jobId.Should().Be(finalJob!.Id);
         statusAtInsert.Should().Be(AtomizerJobStatus.Processing);
+        attemptsAtInsert.Should().Be(0);
         statusAtDispatch.Should().Be(AtomizerJobStatus.Processing);
         finalJob.QueueKey.Should().Be(queue);
         finalJob.PayloadType.Should().Be(typeof(DirectPayload));
@@ -165,6 +177,76 @@ public class AtomizerClientTests
         finalJob.CompletedAt.Should().BeNull();
         finalJob.Errors.Should().ContainSingle();
         finalJob.Errors.Single().ExceptionType.Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenCancellationIsRequested_ShouldReleaseJobWithoutFailure()
+    {
+        using var cts = new CancellationTokenSource();
+        var payload = new DirectPayload("send");
+        AtomizerJob? finalJob = null;
+        _jobSerializer.Serialize(payload).Returns("{\"Message\":\"send\"}");
+        _dispatcher
+            .DispatchAsync(Arg.Any<AtomizerJob>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                cts.Cancel();
+                return Task.FromException(new OperationCanceledException(cts.Token));
+            });
+        _storage
+            .InsertAsync(Arg.Any<AtomizerJob>(), Arg.Any<CancellationToken>())
+            .Returns(call => ((AtomizerJob)call[0]!).Id);
+        _storage
+            .UpdateJobsAsync(
+                Arg.Do<IEnumerable<AtomizerJob>>(jobs => finalJob = jobs.Single()),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => sut.ExecuteAsync(payload, cancellation: cts.Token));
+
+        finalJob.Should().NotBeNull();
+        finalJob!.Status.Should().Be(AtomizerJobStatus.Pending);
+        finalJob.Attempts.Should().Be(0);
+        finalJob.LeaseToken.Should().BeNull();
+        finalJob.VisibleAt.Should().BeNull();
+        finalJob.FailedAt.Should().BeNull();
+        finalJob.Errors.Should().BeEmpty();
+        await _storage
+            .Received(1)
+            .UpdateJobsAsync(
+                Arg.Any<IEnumerable<AtomizerJob>>(),
+                Arg.Is<CancellationToken>(token => token == CancellationToken.None)
+            );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenJobIsInserted_ShouldRegisterHeartbeatBeforeInsert()
+    {
+        var payload = new DirectPayload("send");
+        _jobSerializer.Serialize(payload).Returns("{\"Message\":\"send\"}");
+        _dispatcher.DispatchAsync(Arg.Any<AtomizerJob>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+        _storage
+            .InsertAsync(Arg.Any<AtomizerJob>(), Arg.Any<CancellationToken>())
+            .Returns(call => ((AtomizerJob)call[0]!).Id);
+        _storage
+            .UpdateJobsAsync(Arg.Any<IEnumerable<AtomizerJob>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        await sut.ExecuteAsync(payload, cancellation: TestContext.Current.CancellationToken);
+
+        Received.InOrder(() =>
+        {
+            _storage.UpsertHeartbeatAsync(
+                Arg.Is<AtomizerActiveServer>(server =>
+                    server.InstanceId == _identity.InstanceId && server.LastHeartbeatAt == _now
+                ),
+                TestContext.Current.CancellationToken
+            );
+            _storage.InsertAsync(Arg.Any<AtomizerJob>(), TestContext.Current.CancellationToken);
+        });
     }
 
     private AtomizerClient CreateSut() =>

--- a/tests/Atomizer.Tests/Core/AtomizerClientTests.cs
+++ b/tests/Atomizer.Tests/Core/AtomizerClientTests.cs
@@ -1,0 +1,174 @@
+using Atomizer.Abstractions;
+using Atomizer.Core;
+
+namespace Atomizer.Tests.Core;
+
+public class AtomizerClientTests
+{
+    private readonly IAtomizerServiceScopeFactory _serviceScopeFactory = Substitute.For<IAtomizerServiceScopeFactory>();
+    private readonly IAtomizerServiceScope _serviceScope = Substitute.For<IAtomizerServiceScope>();
+    private readonly IAtomizerStorage _storage = Substitute.For<IAtomizerStorage>();
+    private readonly IAtomizerJobSerializer _jobSerializer = Substitute.For<IAtomizerJobSerializer>();
+    private readonly IAtomizerClock _clock = Substitute.For<IAtomizerClock>();
+    private readonly IAtomizerJobDispatcher _dispatcher = Substitute.For<IAtomizerJobDispatcher>();
+    private readonly AtomizerRuntimeIdentity _identity = new("test-instance");
+    private readonly TestableLogger<AtomizerClient> _logger = Substitute.For<TestableLogger<AtomizerClient>>();
+    private readonly DateTimeOffset _now = DateTimeOffset.UtcNow;
+
+    public AtomizerClientTests()
+    {
+        _clock.UtcNow.Returns(_now);
+        _serviceScope.Storage.Returns(_storage);
+        _serviceScopeFactory.CreateScope().Returns(_serviceScope);
+    }
+
+    [Fact]
+    public async Task DequeueAsync_WhenJobIsPending_ShouldCancelJobAndPersist()
+    {
+        var job = AtomizerJob.Create(QueueKey.Default, typeof(DirectPayload), "{}", _now, _now);
+        _storage.GetJobByIdAsync(job.Id, Arg.Any<CancellationToken>()).Returns(job);
+        var sut = CreateSut();
+
+        var dequeued = await sut.DequeueAsync(job.Id, TestContext.Current.CancellationToken);
+
+        dequeued.Should().BeTrue();
+        job.Status.Should().Be(AtomizerJobStatus.Cancelled);
+        job.UpdatedAt.Should().Be(_now);
+        await _storage
+            .Received(1)
+            .UpdateJobsAsync(
+                Arg.Is<IEnumerable<AtomizerJob>>(jobs => jobs.Single() == job),
+                TestContext.Current.CancellationToken
+            );
+    }
+
+    [Fact]
+    public async Task DequeueAsync_WhenJobIsNotPending_ShouldReturnFalseWithoutPersisting()
+    {
+        var job = AtomizerJob.Create(QueueKey.Default, typeof(DirectPayload), "{}", _now, _now);
+        job.Lease(
+            new LeaseToken($"worker{LeaseToken.Delimiter}{QueueKey.Default}{LeaseToken.Delimiter}{Guid.NewGuid():N}"),
+            _now,
+            TimeSpan.FromMinutes(1)
+        );
+        job.Attempt();
+        job.MarkAsCompleted(_now);
+        _storage.GetJobByIdAsync(job.Id, Arg.Any<CancellationToken>()).Returns(job);
+        var sut = CreateSut();
+
+        var dequeued = await sut.DequeueAsync(job.Id, TestContext.Current.CancellationToken);
+
+        dequeued.Should().BeFalse();
+        await _storage
+            .DidNotReceive()
+            .UpdateJobsAsync(Arg.Any<IEnumerable<AtomizerJob>>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task DeleteRecurringAsync_WhenScheduleExists_ShouldDeleteSchedule()
+    {
+        var jobKey = new JobKey("daily-report");
+        _storage.DeleteScheduleAsync(jobKey, Arg.Any<CancellationToken>()).Returns(true);
+        var sut = CreateSut();
+
+        var deleted = await sut.DeleteRecurringAsync(jobKey, TestContext.Current.CancellationToken);
+
+        deleted.Should().BeTrue();
+        await _storage.Received(1).DeleteScheduleAsync(jobKey, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task DeleteRecurringAsync_WhenScheduleDoesNotExist_ShouldReturnFalse()
+    {
+        var jobKey = new JobKey("missing-report");
+        _storage.DeleteScheduleAsync(jobKey, Arg.Any<CancellationToken>()).Returns(false);
+        var sut = CreateSut();
+
+        var deleted = await sut.DeleteRecurringAsync(jobKey, TestContext.Current.CancellationToken);
+
+        deleted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHandlerSucceeds_ShouldStoreCompletedJob()
+    {
+        var payload = new DirectPayload("send");
+        var queue = new QueueKey("critical");
+        AtomizerJob? finalJob = null;
+        AtomizerJobStatus? statusAtInsert = null;
+        AtomizerJobStatus? statusAtDispatch = null;
+        _jobSerializer.Serialize(payload).Returns("{\"Message\":\"send\"}");
+        _dispatcher
+            .DispatchAsync(Arg.Do<AtomizerJob>(job => statusAtDispatch = job.Status), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        _storage
+            .InsertAsync(Arg.Do<AtomizerJob>(job => statusAtInsert = job.Status), Arg.Any<CancellationToken>())
+            .Returns(call => ((AtomizerJob)call[0]!).Id);
+        _storage
+            .UpdateJobsAsync(
+                Arg.Do<IEnumerable<AtomizerJob>>(jobs => finalJob = jobs.Single()),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        var jobId = await sut.ExecuteAsync(
+            payload,
+            options => options.Queue = queue,
+            TestContext.Current.CancellationToken
+        );
+
+        finalJob.Should().NotBeNull();
+        jobId.Should().Be(finalJob!.Id);
+        statusAtInsert.Should().Be(AtomizerJobStatus.Processing);
+        statusAtDispatch.Should().Be(AtomizerJobStatus.Processing);
+        finalJob.QueueKey.Should().Be(queue);
+        finalJob.PayloadType.Should().Be(typeof(DirectPayload));
+        finalJob.Payload.Should().Be("{\"Message\":\"send\"}");
+        finalJob.Attempts.Should().Be(1);
+        finalJob.Status.Should().Be(AtomizerJobStatus.Completed);
+        finalJob.CompletedAt.Should().Be(_now);
+        finalJob.FailedAt.Should().BeNull();
+        finalJob.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenHandlerFails_ShouldStoreFailedJobAndRethrow()
+    {
+        var payload = new DirectPayload("send");
+        var exception = new InvalidOperationException("boom");
+        AtomizerJob? finalJob = null;
+        AtomizerJobStatus? statusAtInsert = null;
+        _jobSerializer.Serialize(payload).Returns("{\"Message\":\"send\"}");
+        _dispatcher.DispatchAsync(Arg.Any<AtomizerJob>(), Arg.Any<CancellationToken>()).Returns(_ => throw exception);
+        _storage
+            .InsertAsync(Arg.Do<AtomizerJob>(job => statusAtInsert = job.Status), Arg.Any<CancellationToken>())
+            .Returns(call => ((AtomizerJob)call[0]!).Id);
+        _storage
+            .UpdateJobsAsync(
+                Arg.Do<IEnumerable<AtomizerJob>>(jobs => finalJob = jobs.Single()),
+                Arg.Any<CancellationToken>()
+            )
+            .Returns(Task.CompletedTask);
+        var sut = CreateSut();
+
+        var thrown = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ExecuteAsync(payload, cancellation: TestContext.Current.CancellationToken)
+        );
+
+        thrown.Should().BeSameAs(exception);
+        finalJob.Should().NotBeNull();
+        statusAtInsert.Should().Be(AtomizerJobStatus.Processing);
+        finalJob!.Status.Should().Be(AtomizerJobStatus.Failed);
+        finalJob.Attempts.Should().Be(1);
+        finalJob.FailedAt.Should().Be(_now);
+        finalJob.CompletedAt.Should().BeNull();
+        finalJob.Errors.Should().ContainSingle();
+        finalJob.Errors.Single().ExceptionType.Should().Be(typeof(InvalidOperationException).FullName);
+    }
+
+    private AtomizerClient CreateSut() =>
+        new AtomizerClient(_serviceScopeFactory, _jobSerializer, _clock, _dispatcher, _identity, _logger);
+
+    private sealed record DirectPayload(string Message);
+}

--- a/tests/Atomizer.Tests/Core/AtomizerClientTests.cs
+++ b/tests/Atomizer.Tests/Core/AtomizerClientTests.cs
@@ -26,6 +26,16 @@ public class AtomizerClientTests
     }
 
     [Fact]
+    public void Constructor_WhenDispatcherIsNull_ShouldThrow()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() =>
+            new AtomizerClient(_serviceScopeFactory, _jobSerializer, _clock, null!, _identity, _logger)
+        );
+
+        exception.ParamName.Should().Be("dispatcher");
+    }
+
+    [Fact]
     public async Task DequeueAsync_WhenJobIsPending_ShouldCancelJobAndPersist()
     {
         var job = AtomizerJob.Create(QueueKey.Default, typeof(DirectPayload), "{}", _now, _now);


### PR DESCRIPTION
## Summary
- Adds public client actions for cancelling pending jobs, deleting recurring schedules idempotently, and executing handlers immediately while recording terminal status.
- Extends storage contracts and backends so recurring schedules can be deleted consistently across in-memory, EF Core, and Redis.
- Updates README and sample projects with direct execution, dequeue, delete recurring examples, plus dashboard feature-section screenshot placement.
- Checked with `dotnet csharpier check .`, `dotnet build Atomizer.sln`, and focused `AtomizerClientTests` on `net8.0`.

## Changes
- Adds `IAtomizerClient.DequeueAsync`, `DeleteRecurringAsync`, and `ExecuteAsync`, plus core implementation tests.
- Adds `IAtomizerStorage.DeleteScheduleAsync` with provider implementations and storage contract coverage.
- Adds sample API endpoints and `.http` examples for the new client actions.
- Refreshes README dashboard wording so it no longer describes the action-capable dashboard as read-only.