### PR TITLE
fix(dashboard): hide atomizer endpoints from openapi

### DIFF
--- a/src/Atomizer.Dashboard/Configuration/DashboardEndpointRouteExtensions.cs
+++ b/src/Atomizer.Dashboard/Configuration/DashboardEndpointRouteExtensions.cs
@@ -1,6 +1,7 @@
 using Atomizer.Dashboard.Authorization;
 using Atomizer.Dashboard.Endpoints;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 
 namespace Atomizer;
@@ -22,63 +23,94 @@ public static class DashboardEndpointRouteExtensions
     {
         var prefix = routePrefix.TrimEnd('/');
 
-        endpoints.MapGet(
+        MapDashboardGet(
+            endpoints,
             prefix + "/api/jobs",
             DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.ListAsync(ctx))
         );
-        endpoints.MapGet(
+        MapDashboardGet(
+            endpoints,
             prefix + "/api/jobs/{id:guid}",
             DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.GetByIdAsync(ctx))
         );
-        endpoints.MapGet(
+        MapDashboardGet(
+            endpoints,
             prefix + "/api/job-types",
             DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.ListJobTypesAsync(ctx))
         );
-        endpoints.MapPost(
+        MapDashboardPost(
+            endpoints,
             prefix + "/api/jobs/trigger",
             DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.TriggerAsync(ctx))
         );
-        endpoints.MapPost(
+        MapDashboardPost(
+            endpoints,
             prefix + "/api/jobs/{id:guid}/retry",
             DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.RetryAsync(ctx))
         );
-        endpoints.MapPost(
+        MapDashboardPost(
+            endpoints,
             prefix + "/api/jobs/{id:guid}/cancel",
             DashboardAuthorizationFilter.Wrap<JobsEndpointHandler>((handler, ctx) => handler.CancelAsync(ctx))
         );
-        endpoints.MapGet(
+        MapDashboardGet(
+            endpoints,
             prefix + "/api/schedules",
             DashboardAuthorizationFilter.Wrap<SchedulesEndpointHandler>((handler, ctx) => handler.ListAsync(ctx))
         );
-        endpoints.MapPost(
+        MapDashboardPost(
+            endpoints,
             prefix + "/api/schedules/{id:guid}/enabled",
             DashboardAuthorizationFilter.Wrap<SchedulesEndpointHandler>((handler, ctx) => handler.SetEnabledAsync(ctx))
         );
-        endpoints.MapPost(
+        MapDashboardPost(
+            endpoints,
             prefix + "/api/schedules/{id:guid}/run-now",
             DashboardAuthorizationFilter.Wrap<SchedulesEndpointHandler>((handler, ctx) => handler.RunNowAsync(ctx))
         );
-        endpoints.MapGet(
+        MapDashboardGet(
+            endpoints,
             prefix + "/api/queues/stats",
             DashboardAuthorizationFilter.Wrap<QueueStatsEndpointHandler>((handler, ctx) => handler.GetStatsAsync(ctx))
         );
-        endpoints.MapGet(
+        MapDashboardGet(
+            endpoints,
             prefix + "/api/servers",
             DashboardAuthorizationFilter.Wrap<ServersEndpointHandler>((handler, ctx) => handler.ListAsync(ctx))
         );
 
-        endpoints.MapGet(
+        MapDashboardGet(
+            endpoints,
             prefix,
             DashboardAuthorizationFilter.Wrap<StaticFilesEndpointHandler>(
                 (handler, ctx) => handler.ServeIndexAsync(ctx, prefix)
             )
         );
 
-        return endpoints.MapGet(
+        return MapDashboardGet(
+            endpoints,
             prefix + "/{**path}",
             DashboardAuthorizationFilter.Wrap<StaticFilesEndpointHandler>(
                 (handler, ctx) => handler.ServeAsync(ctx, prefix)
             )
         );
+    }
+
+    private static RouteHandlerBuilder MapDashboardGet(
+        IEndpointRouteBuilder endpoints,
+        string pattern,
+        Delegate handler
+    )
+    {
+        return endpoints.MapGet(pattern, handler).ExcludeFromDescription();
+    }
+
+    private static RouteHandlerBuilder MapDashboardPost(
+        IEndpointRouteBuilder endpoints,
+        string pattern,
+        Delegate handler
+    )
+    {
+        return endpoints.MapPost(pattern, handler).ExcludeFromDescription();
     }
 }

--- a/tests/Atomizer.Dashboard.Tests/Configuration/DashboardEndpointRouteExtensionsTests.cs
+++ b/tests/Atomizer.Dashboard.Tests/Configuration/DashboardEndpointRouteExtensionsTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Atomizer.Dashboard.Tests.Configuration;
+
+public class DashboardEndpointRouteExtensionsTests : IClassFixture<DashboardTestHost>
+{
+    private readonly DashboardTestHost _host;
+
+    public DashboardEndpointRouteExtensionsTests(DashboardTestHost host)
+    {
+        _host = host;
+    }
+
+    [Fact]
+    public void MapAtomizerDashboard_WhenEndpointApiExplorerIsRegistered_ShouldExcludeDashboardEndpoints()
+    {
+        _host.CreateClient();
+
+        var descriptions = _host.Services.GetRequiredService<IApiDescriptionGroupCollectionProvider>();
+
+        var paths = descriptions
+            .ApiDescriptionGroups.Items.SelectMany(group => group.Items)
+            .Select(description => description.RelativePath)
+            .ToList();
+
+        paths.Should().NotContain(path => path != null && (path == "atomizer" || path.StartsWith("atomizer/")));
+    }
+}

--- a/tests/Atomizer.Dashboard.Tests/TestHost.cs
+++ b/tests/Atomizer.Dashboard.Tests/TestHost.cs
@@ -24,6 +24,7 @@ public abstract class DashboardHostBase : WebApplicationFactory<Program>
                 web.ConfigureServices(services =>
                 {
                     services.AddRouting();
+                    services.AddEndpointsApiExplorer();
                     services.AddAtomizer(options =>
                     {
                         options.UseInMemoryStorage();

--- a/tests/Atomizer.Tests/Processing/QueuePollerTests.cs
+++ b/tests/Atomizer.Tests/Processing/QueuePollerTests.cs
@@ -211,7 +211,7 @@ namespace Atomizer.Tests.Processing
         {
             // Arrange
             var channel = Channel.CreateUnbounded<JobBatch>();
-            var leaseAttemptCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var cts = new CancellationTokenSource();
             _storage
                 .ExecuteInLeaseAsync(
                     Arg.Any<QueueKey>(),
@@ -222,19 +222,15 @@ namespace Atomizer.Tests.Processing
                 {
                     var callback = callInfo.ArgAt<Func<CancellationToken, Task<List<AtomizerJob>>>>(1);
                     var jobs = await callback(CancellationToken.None);
-                    leaseAttemptCompleted.TrySetResult();
+                    cts.Cancel();
                     return jobs;
                 });
             _storage
                 .GetDueJobsAsync(_queueOptions.QueueKey, _now, _queueOptions.BatchSize, Arg.Any<CancellationToken>())
                 .Returns(new List<AtomizerJob>());
 
-            using var cts = new CancellationTokenSource();
-
             // Act
             var runTask = _sut.RunAsync(_queueOptions, _leaseToken, channel, cts.Token);
-            await leaseAttemptCompleted.Task.WaitAsync(Timeout, TestContext.Current.CancellationToken);
-            cts.Cancel();
             (await WaitOrTimeout(runTask, Timeout)).Should().BeTrue();
 
             // Assert


### PR DESCRIPTION
## Summary
- Hide Atomizer dashboard routes from API Explorer so consumer Swagger and OpenAPI documents no longer include internal dashboard endpoints.
- Keep dashboard route registration centralized while applying the exclusion metadata consistently.

## Changes
- Added dashboard GET/POST mapping helpers that call `ExcludeFromDescription()`.
- Added API Explorer coverage proving no `/atomizer` dashboard paths are described.
- Registered endpoint API Explorer in the dashboard test host for the regression case.
- Checked with `dotnet csharpier check`, dashboard tests on `net8.0` and `net10.0`, and the dashboard package build with `SkipSpaBuild=true`; the existing `System.Text.Json` NU1903 warning remains.